### PR TITLE
Fix variables leaking from config file scope breaking codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.1] - 2017-12-01
+
+### Changed
+- Fixed minor issue where variables with certain names defined in the included configuration container's file could impact the code generation scripts
+
 ## [3.0.0] - 2017-12-01
 
 ### Summary of Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Fixed minor issue where variables with certain names defined in the included configuration container's file could impact the code generation scripts
+- Fixed issue in generated front controller where config file would be loaded twice
 
 ## [3.0.0] - 2017-12-01
 

--- a/bin/generate_front_controller
+++ b/bin/generate_front_controller
@@ -49,7 +49,7 @@ set_exception_handler([$handler, 'handleThrowable']);
 
 
 $response = (new Dispatcher())
-    ->setContainer(%s)
+    ->setContainer($config)
     ->setEndpointList('__endpoint_list__.json')
     ->setParserList('__parser_list__.json')
     ->setRequest(ServerRequestFactory::fromGlobals())
@@ -70,7 +70,6 @@ $container = array_key_exists('container', $config)
 $fc = sprintf(
     $template,
     resolveProjectRoot($config['webroot']),
-    $container,
     $container
 );
 


### PR DESCRIPTION
If the configured `container` file had a variable named `$config`, it would overwrite the value in `bin/load_config.php`, replacing what is returned by the file. This was an oversight during development since testing was performed by pointing to a file returning an anonymous class, rather than something that better resembles a common config file.