### PR TITLE
Add URI matching into endpoint test case trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.2] - UNRELEASED
+- Added URI matching tests into `EndpointTestCases`. Updating to this version will result in existing passing tests using said trait being skipped until good and bad URI matches are added into the test case.
+
 ## [3.0.1] - 2017-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.2] - UNRELEASED
+## [3.0.2] - 2018-01-03
 - Added URI matching tests into `EndpointTestCases`. Updating to this version will result in existing passing tests using said trait being skipped until good and bad URI matches are added into the test case.
 
 ## [3.0.1] - 2017-12-01

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -38,4 +38,29 @@ class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
             $this->assertInstanceOf(Throwable::Class, $testParam);
         }
     }
+
+    public function goodUris(): array
+    {
+        return [
+            '/user/1' => ['id' => '1'],
+            '/user/10' => ['id' => '10'],
+            '/user/3' => ['id' => '3'],
+            '/user/134098435089225' => ['id' => '134098435089225'],
+        ];
+    }
+
+    public function badUris(): array
+    {
+        return [
+            '/',
+            '/0/user/',
+            '/3/user',
+            'user/3',
+            '/user',
+            '/user/',
+            '/user/0',
+            '/user/01234',
+            '/user/username',
+        ];
+    }
 }

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -17,10 +17,13 @@ use Throwable;
  * @covers Firehed\API\Traits\EndpointTestCases::testGetMethod
  * @covers Firehed\API\Traits\EndpointTestCases::testHandleException
  */
-class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
+class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
 {
 
-    use EndpointTestCases;
+    use EndpointTestCases {
+        goodUris as baseGoodUris;
+        badUris as baseBadUris;
+    }
 
     protected function getEndpoint(): EndpointInterface
     {
@@ -35,16 +38,27 @@ class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
         $data = $this->exceptionsToHandle();
         foreach ($data as $testCase) {
             list($testParam) = $testCase;
-            $this->assertInstanceOf(Throwable::Class, $testParam);
+            $this->assertInstanceOf(Throwable::class, $testParam);
         }
     }
 
     /**
      * @covers Firehed\API\Traits\EndpointTestCases::uris
      */
+    public function testUris()
+    {
+        $data = $this->uris();
+        foreach ($data as $testCase) {
+            list($uri, $shouldMatch, $matches) = $testCase;
+            $this->assertInternalType('string', $uri);
+            $this->assertInternalType('bool', $shouldMatch);
+            $this->assertInternalType('array', $matches);
+        }
+    }
+
     public function goodUris(): array
     {
-        return [
+        return $this->baseGoodUris() + [
             '/user/1' => ['id' => '1'],
             '/user/10' => ['id' => '10'],
             '/user/3' => ['id' => '3'],
@@ -52,12 +66,9 @@ class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @covers Firehed\API\Traits\EndpointTestCases::uris
-     */
     public function badUris(): array
     {
-        return [
+        return $this->baseBadUris() + [
             '/',
             '/0/user/',
             '/3/user',

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -39,6 +39,9 @@ class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * @covers Firehed\API\Traits\EndpointTestCases::uris
+     */
     public function goodUris(): array
     {
         return [
@@ -49,6 +52,9 @@ class EndpointTestTraitTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * @covers Firehed\API\Traits\EndpointTestCases::uris
+     */
     public function badUris(): array
     {
         return [


### PR DESCRIPTION
Allows developers to easily test what their URIs do and do not match.