### PR TITLE
Add @method annotations to help static analysis tools

### DIFF
--- a/src/Enums/HTTPMethod.php
+++ b/src/Enums/HTTPMethod.php
@@ -6,6 +6,13 @@ namespace Firehed\API\Enums;
 
 use Firehed\Common\Enum;
 
+/**
+ * @method static HTTPMethod DELETE()
+ * @method static HTTPMethod GET()
+ * @method static HTTPMethod OPTIONS()
+ * @method static HTTPMethod POST()
+ * @method static HTTPMethod PUT()
+ */
 class HTTPMethod extends Enum
 {
 


### PR DESCRIPTION
This helps tools like PHPStan not emit error messages like "Call to an undefined static method Firehed\API\Enums\HTTPMethod::GET()." IDEs probably benefit as well.