### PR TITLE
Indicate a 415 error code for invalid inputs

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -181,7 +181,7 @@ class Dispatcher
         if ($header) {
             $directives = explode(';', $header[0]);
             if (!count($directives)) {
-                throw new OutOfBoundsException('Invalid Content-type header', 400);
+                throw new OutOfBoundsException('Invalid Content-type header', Enums\HTTPResponse::UNSUPPORTED_MEDIA_TYPE);
             }
             $mediaType = array_shift($directives);
             // Future: trim and format directives; e.g. ' charset=utf-8' =>
@@ -189,7 +189,7 @@ class Dispatcher
             list($parser_class) = (new ClassMapper($this->parser_list))
                 ->search($mediaType);
             if (!$parser_class) {
-                throw new OutOfBoundsException('Unsupported Content-type', 400);
+                throw new OutOfBoundsException('Unsupported Content-type', Enums\HTTPResponse::UNSUPPORTED_MEDIA_TYPE);
             }
             $parser = new $parser_class;
             $data = $parser->parse((string)$this->request->getBody());

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -181,7 +181,7 @@ class Dispatcher
         if ($header) {
             $directives = explode(';', $header[0]);
             if (!count($directives)) {
-                throw new OutOfBoundsException('Invalid Content-type header', Enums\HTTPResponse::UNSUPPORTED_MEDIA_TYPE);
+                throw new OutOfBoundsException('Invalid Content-type header', 415);
             }
             $mediaType = array_shift($directives);
             // Future: trim and format directives; e.g. ' charset=utf-8' =>
@@ -189,7 +189,7 @@ class Dispatcher
             list($parser_class) = (new ClassMapper($this->parser_list))
                 ->search($mediaType);
             if (!$parser_class) {
-                throw new OutOfBoundsException('Unsupported Content-type', Enums\HTTPResponse::UNSUPPORTED_MEDIA_TYPE);
+                throw new OutOfBoundsException('Unsupported Content-type', 415);
             }
             $parser = new $parser_class;
             $data = $parser->parse((string)$this->request->getBody());

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -412,7 +412,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->setRequest($req)
             ->dispatch();
         $this->assertSame(
-            EndpointFixture::STATUS_ERROR,
+            415,
             $response->getStatusCode()
         );
     }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -411,17 +411,10 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->setParserList($this->getDefaultParserList())
             ->setRequest($req)
             ->dispatch();
-        try {
         $this->assertSame(
             415,
             $response->getStatusCode()
         );
-        } catch (\Throwable $e) {
-            echo $e;
-            echo $response->getBody();
-            throw $e;
-        }
-
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -411,10 +411,17 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->setParserList($this->getDefaultParserList())
             ->setRequest($req)
             ->dispatch();
+        try {
         $this->assertSame(
             415,
             $response->getStatusCode()
         );
+        } catch (\Throwable $e) {
+            echo $e;
+            echo $response->getBody();
+            throw $e;
+        }
+
     }
 
     /**

--- a/tests/EndpointFixture.php
+++ b/tests/EndpointFixture.php
@@ -81,8 +81,12 @@ class EndpointFixture implements Interfaces\EndpointInterface
     {
         $mock = (new Generator())
             ->getMock(Response::class);
+        $code = $e->getCode();
+        if ($code < 200 || $code > 599) {
+            $code = self::STATUS_ERROR; // Artificial test value
+        }
         $mock->method('getStatusCode')
-            ->will(new ReturnStub(self::STATUS_ERROR)); // Artificial test value
+            ->will(new ReturnStub($code));
         return $mock;
     }
 }

--- a/tests/EndpointFixture.php
+++ b/tests/EndpointFixture.php
@@ -87,6 +87,8 @@ class EndpointFixture implements Interfaces\EndpointInterface
         }
         $mock->method('getStatusCode')
             ->will(new ReturnStub($code));
+        $mock->method('getBody')
+            ->will(new ReturnStub($e)); // This is incorrect, but makes debugging tests easier
         return $mock;
     }
 }


### PR DESCRIPTION
Fixes #21 - although it's admittedly imperfect since it's not actually creating a 415 response, but instead allows for error handlers to see the error code and dispatch it correctly.