### PR TITLE
Allow top-level error handler within dispatcher

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -12,6 +12,7 @@ use Firehed\Input\Containers\ParsedInput;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
@@ -157,7 +158,7 @@ class Dispatcher
                 // If an application-wide handler has been defined, use the
                 // response that it generates. If not, just rethrow the
                 // exception for the system default (if defined) to handle.
-                if ($this->error_handler) {
+                if ($this->error_handler && $this->request instanceof ServerRequestInterface) {
                     $response = $this->error_handler->handle($this->request, $e);
                 } else {
                     throw $e;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,11 +6,13 @@ namespace Firehed\API;
 
 use BadMethodCallException;
 use DomainException;
+use Firehed\API\Interfaces\ErrorHandlerInterface;
 use Firehed\Common\ClassMapper;
 use Firehed\Input\Containers\ParsedInput;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
 
@@ -61,6 +63,19 @@ class Dispatcher
     public function setContainer(ContainerInterface $container = null): self
     {
         $this->container = $container;
+        return $this;
+    }
+
+    /**
+     * Provide a default error handler. This will be used in the event that an
+     * endpoint does not define its own handler.
+     *
+     * @param ErrorHandlerInterface $handler
+     * @return self
+     */
+    public function setErrorHandler(ErrorHandlerInterface $handler): self
+    {
+        $this->error_handler = $handler;
         return $this;
     }
 
@@ -135,8 +150,19 @@ class Dispatcher
                 ->validate($endpoint);
 
             $response = $endpoint->execute($safe_input);
-        } catch (\Throwable $e) {
-            $response = $endpoint->handleException($e);
+        } catch (Throwable $e) {
+            try {
+                $response = $endpoint->handleException($e);
+            } catch (Throwable $e) {
+                // If an application-wide handler has been defined, use the
+                // response that it generates. If not, just rethrow the
+                // exception for the system default (if defined) to handle.
+                if ($this->error_handler) {
+                    $response = $this->error_handler->handle($this->request, $e);
+                } else {
+                    throw $e;
+                }
+            }
         }
         return $this->executeResponseMiddleware($response);
     }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -7,6 +7,11 @@ use ErrorException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+/**
+ * This will be deprecated in the next minor release and removed in the next
+ * major release. Instead, prefer to provide an ErrorHandlerInterface to the
+ * Dispatcher.
+ */
 class ErrorHandler
 {
     /** @var LoggerInterface */

--- a/src/Interfaces/ErrorHandlerInterface.php
+++ b/src/Interfaces/ErrorHandlerInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\API\Interfaces;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+interface ErrorHandlerInterface
+{
+    /**
+     * Handle an exception for the given request. It is RECOMMENDED that
+     * implementations use the $request's accept header to determine how best
+     * to build the response.
+     */
+    public function handle(ServerRequestInterface $request, Throwable $t): ResponseInterface;
+}

--- a/src/Interfaces/ErrorHandlerInterface.php
+++ b/src/Interfaces/ErrorHandlerInterface.php
@@ -12,7 +12,7 @@ interface ErrorHandlerInterface
     /**
      * Handle an exception for the given request. It is RECOMMENDED that
      * implementations use the $request's accept header to determine how best
-     * to build the response.
+     * to format the response.
      */
     public function handle(ServerRequestInterface $request, Throwable $t): ResponseInterface;
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -489,7 +489,10 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $this->executeMockRequestOnEndpoint($endpoint);
     }
 
-    /** @covers ::dispatch */
+    /**
+     * @covers ::dispatch
+     * @covers ::setErrorHandler
+     */
     public function testExceptionsReachDefaultErrorHandlerWhenSet()
     {
         $e = new Exception('This should reach the main error handler');
@@ -506,7 +509,11 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnCallback($cb));
 
         $dispatcher = new Dispatcher();
-        $dispatcher->setErrorHandler($handler);
+        $this->assertSame(
+            $dispatcher,
+            $dispatcher->setErrorHandler($handler),
+            'setErrorHandler should return $this'
+        );
 
         $endpoint = $this->getMockEndpoint();
         $endpoint->method('execute')


### PR DESCRIPTION
This creates a new interface for handling any exception that an endpoint throws without forcing the endpoint to implement its own error handler. 

The end-goal for this is to be able to extract the `handleException` method in `EndpointInterface` into its own interface, so that in the next major (?) version, error handling at a per-endpoint level becomes completely optional. This cuts way down on boilerplate, since relatively few endpoints (in my experience) need their own error handling logic, and the main use case for that tended to be for formatting the response to an appropriate content-type based on what was implied (but not actually stated!) by the request.