### PR TITLE
Error interface adjustments to prepare for next major version

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,11 +6,13 @@ namespace Firehed\API;
 
 use BadMethodCallException;
 use DomainException;
+use Firehed\API\Interfaces\ErrorHandlerInterface;
 use Firehed\Common\ClassMapper;
 use Firehed\Input\Containers\ParsedInput;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
 
@@ -61,6 +63,19 @@ class Dispatcher
     public function setContainer(ContainerInterface $container = null): self
     {
         $this->container = $container;
+        return $this;
+    }
+
+    /**
+     * Provide a default error handler. This will be used in the event that an
+     * endpoint does not define its own handler.
+     *
+     * @param ErrorHandlerInterface $handler
+     * @return self
+     */
+    public function setErrorHandler(ErrorHandlerInterface $handler): self
+    {
+        $this->error_handler = $handler;
         return $this;
     }
 
@@ -135,8 +150,19 @@ class Dispatcher
                 ->validate($endpoint);
 
             $response = $endpoint->execute($safe_input);
-        } catch (\Throwable $e) {
-            $response = $endpoint->handleException($e);
+        } catch (Throwable $e) {
+            try {
+                $response = $endpoint->handleException($e);
+            } catch (Throwable $e) {
+                // If an application-wide handler has been defined, use the
+                // response that it generates. If not, just rethrow the
+                // exception for the system default (if defined) to handle.
+                if ($this->error_handler) {
+                    $response = $this->error_handler->handle($this->request, $e);
+                } else {
+                    throw $e;
+                }
+            }
         }
         return $this->executeResponseMiddleware($response);
     }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -7,6 +7,7 @@ namespace Firehed\API;
 use BadMethodCallException;
 use DomainException;
 use Firehed\API\Interfaces\ErrorHandlerInterface;
+use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
 use Firehed\Common\ClassMapper;
 use Firehed\Input\Containers\ParsedInput;
 use Psr\Container\ContainerInterface;
@@ -152,7 +153,11 @@ class Dispatcher
             $response = $endpoint->execute($safe_input);
         } catch (Throwable $e) {
             try {
-                $response = $endpoint->handleException($e);
+                if ($endpoint instanceof HandlesOwnErrorsInterface) {
+                    $response = $endpoint->handleException($e);
+                } else {
+                    throw $e;
+                }
             } catch (Throwable $e) {
                 // If an application-wide handler has been defined, use the
                 // response that it generates. If not, just rethrow the

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -7,6 +7,11 @@ use ErrorException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+/**
+ * This will be deprecated in the next minor release and removed in the next
+ * major release. Instead, prefer to provide an ErrorHandlerInterface to the
+ * Dispatcher.
+ */
 class ErrorHandler
 {
     /** @var LoggerInterface */

--- a/src/Interfaces/EndpointInterface.php
+++ b/src/Interfaces/EndpointInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\API\Interfaces;
 
-use Throwable;
 use Firehed\API\Enums\HTTPMethod;
 use Firehed\Input\Containers\SafeInput;
 use Firehed\Input\Interfaces\ValidationInterface;
@@ -20,8 +19,13 @@ use Psr\Http\Message\ResponseInterface as Response;
  * be configuired with a container injected into the Dispatcher. If there are
  * no paramters on the constructor (or there is no constructor), that is
  * optional.
+ *
+ * In the next major version of this framework, this interface will no longer
+ * extend HandlesOwnErrorsInterface; endpoints that actually have special error
+ * handling logic must explictly implement that interface upon migrating to
+ * that version.
  */
-interface EndpointInterface extends ValidationInterface
+interface EndpointInterface extends ValidationInterface, HandlesOwnErrorsInterface
 {
 
     /**
@@ -89,19 +93,4 @@ interface EndpointInterface extends ValidationInterface
      * @throws \RuntimeException if authentication fails
      */
     public function authenticate(Request $request): self;
-
-    /**
-     * Handle uncaught exceptions
-     *
-     * This method MUST accept any type of Exception and return a PSR-7
-     * ResponseInterface object.
-     *
-     * It is RECOMMENDED to implement this method in a trait, since most
-     * Endpoints will share error handling logic. In most cases, one trait per
-     * supported MIME-type will probably suffice.
-     *
-     * @param Exception The uncaught exception
-     * @return ResponseInterface The response to render
-     */
-    public function handleException(Throwable $e): Response;
 }

--- a/src/Interfaces/ErrorHandlerInterface.php
+++ b/src/Interfaces/ErrorHandlerInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\API\Interfaces;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+interface ErrorHandlerInterface
+{
+    /**
+     * Handle an exception for the given request. It is RECOMMENDED that
+     * implementations use the $request's accept header to determine how best
+     * to build the response.
+     */
+    public function handle(ServerRequestInterface $request, Throwable $t): ResponseInterface;
+}

--- a/src/Interfaces/HandlesOwnErrorsInterface.php
+++ b/src/Interfaces/HandlesOwnErrorsInterface.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\API\Interfaces;
+
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+/**
+ * Interface for Endpoints to indicate that they will handle their own
+ * exceptions. Implementing this interface will be unnecessary in most cases,
+ * preferring to let the application-wide exception handler to deal with common
+ * errors. Note that this may receive exceptions before an endpoint's `execute`
+ * method has been called (e.g. due to an input validation error), and as such
+ * most not rely on any state established at that time (though may choose to
+ * look for such state).
+ */
+interface HandlesOwnErrorsInterface
+{
+    /**
+     * Handle uncaught exceptions
+     *
+     * This method MUST accept any type of Exception and return a PSR-7
+     * ResponseInterface object.
+     *
+     * It is RECOMMENDED to implement this method in a trait, since most
+     * Endpoints will share error handling logic. In most cases, one trait per
+     * supported MIME-type will probably suffice.
+     *
+     * @param Throwable $e The uncaught exception
+     * @return ResponseInterface The response to render
+     */
+    public function handleException(Throwable $e): ResponseInterface;
+}


### PR DESCRIPTION
This moves an endpoint's `handleException` method into its own interface, so that endpoints explicitly indicate that they are capable of handling their own errors. Most endpoints will not implement this interface.

The main `EndpointInterface` has been adjusted to extend this new interface, so that existing behavior will remain unchanged. In the next major version, that will be removed, resulting in two main changes:
- Implementing a new v4 endpoint will require less work, less code, and less boilerplate
- Existing v3 endpoints that have NOT been updated to implement that interface when migrating to v4 will no longer see their error handlers called

Note that the only migration step that will be required in v4 as a result of this change is adding `HandlesOwnErrorsInterface` to the endpoint's existing `implements` list.