### PR TITLE
PSR-15 Middleware Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
     "name": "firehed/api",
     "require": {
+        "php": ">=7",
         "firehed/common": "^1.0",
         "firehed/input": "^2.0",
-        "psr/http-message": "^1.0",
-        "php": ">=7",
-        "zendframework/zend-diactoros": "^1.3",
         "psr/container": "^1.0",
-        "psr/log": "^1.0"
+        "psr/http-message": "^1.0",
+        "psr/http-server-handler": "^1.0",
+        "psr/http-server-middleware": "^1.0",
+        "psr/log": "^1.0",
+        "zendframework/zend-diactoros": "^1.3"
     },
     "suggest": {
         "firehed/inputobjects": "Pre-made Input components for validation"
@@ -44,6 +46,9 @@
             "email": "eric@ericstern.com"
         }
     ],
+    "config": {
+      "sort-packages": true
+    },
     "scripts": {
       "test": [
         "@phpunit",

--- a/composer.json
+++ b/composer.json
@@ -49,9 +49,6 @@
             "email": "eric@ericstern.com"
         }
     ],
-    "config": {
-      "sort-packages": true
-    },
     "scripts": {
       "test": [
         "@phpunit",

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -11,10 +11,12 @@ use Firehed\Input\Containers\ParsedInput;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use OutOfBoundsException;
 use UnexpectedValueException;
 
-class Dispatcher
+class Dispatcher implements RequestHandlerInterface
 {
 
     private $container;
@@ -24,6 +26,15 @@ class Dispatcher
     private $response_middleware = [];
     private $request;
     private $uri_data;
+
+    /**
+     * PSR-15 Entrypoint
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->setRequest($request);
+        return $this->dispatch();
+    }
 
     /**
      * Add a callback to run on the response after controller executation (or

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -16,6 +16,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Throwable;
 
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
 /**
  * @coversDefaultClass Firehed\API\Dispatcher
  * @covers ::<protected>
@@ -312,6 +315,53 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             $this->response_hits,
             'Second callback was fired that should have been bypassed'
         );
+    }
+
+    public function testPsr15()
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $modifiedRequest = $this->getMockRequestWithUriPath('/c', 'GET', [], ServerRequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $modifiedResponse = $this->createMock(ResponseInterface::class);
+
+        $dispatcher = new Dispatcher();
+
+        $mw1 = $this->createMock(MiddlewareInterface::class);
+        $mw1->expects($this->once())
+            ->method('process')
+            ->willReturnCallback(function ($req, $handler) use ($request, $modifiedRequest, $dispatcher) {
+                $this->assertSame($req, $request, 'Request mismatch');
+                $this->assertSame($dispatcher, $handler, 'Handler mismatch');
+                return $handler->handle($modifiedRequest);
+            });
+        $mw2 = $this->createMock(MiddlewareInterface::class);
+        $mw2->expects($this->once())
+            ->method('process')
+            ->willReturnCallback(function ($req, $handler) use ($modifiedRequest, $dispatcher, $response, $modifiedResponse) {
+                $this->assertSame($req, $modifiedRequest, 'Request mismatch');
+                $this->assertSame($dispatcher, $handler, 'Handler mismatch');
+                $endpointResponse = $handler->handle($req);
+                $this->assertSame($response, $endpointResponse, 'Response mismatch');
+                return $modifiedResponse;
+            });
+
+
+        $endpoint = $this->getMockEndpoint();
+        $endpoint->expects($this->atLeastOnce())
+            ->method('execute')
+            ->willReturn($response);
+
+        $routes = ['GET' => ['/c' => 'EP']];
+        $res = $dispatcher
+            ->addMiddleware($mw1)
+            ->addMiddleware($mw2)
+            ->setContainer($this->getMockContainer(['EP' => $endpoint]))
+            ->setEndpointList($routes)
+            ->setParserList($this->getDefaultParserList())
+            ->setRequest($request)
+            ->dispatch();
+
+        $this->assertSame($modifiedResponse, $res, 'Dispatcher returned different response');
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -317,6 +317,11 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @covers ::addMiddleware
+     * @covers ::dispatch
+     * @covers ::handle
+     */
     public function testPsr15()
     {
         $request = $this->createMock(ServerRequestInterface::class);
@@ -337,9 +342,8 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $mw2 = $this->createMock(MiddlewareInterface::class);
         $mw2->expects($this->once())
             ->method('process')
-            ->willReturnCallback(function ($req, $handler) use ($modifiedRequest, $dispatcher, $response, $modifiedResponse) {
+            ->willReturnCallback(function ($req, $handler) use ($modifiedRequest, $response, $modifiedResponse) {
                 $this->assertSame($req, $modifiedRequest, 'Request mismatch');
-                $this->assertSame($dispatcher, $handler, 'Handler mismatch');
                 $endpointResponse = $handler->handle($req);
                 $this->assertSame($response, $endpointResponse, 'Response mismatch');
                 return $modifiedResponse;


### PR DESCRIPTION
Adds PSR-15 middleware support to the dispatcher. Any injected middleware starts to run before all of the routing/auth/validation processes, and will get accessed to any responses modified by the legacy middleware queue.

Fixes #44 
