### PR TITLE
Allow the test trait to permit rethrown exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.1.0] - (tbd)
 ### Added
 - Overhauled authentication (#43)
-- Overhauled error handling (#37, #38)
+- Overhauled error handling (#37, #38, #63)
 - Added support for PSR-15 Middleware (#59)
 ### Changed
 - Internal refactoring

--- a/src/Traits/EndpointTestCases.php
+++ b/src/Traits/EndpointTestCases.php
@@ -16,7 +16,7 @@ use Firehed\Input\ValidationTestTrait;
  */
 trait EndpointTestCases
 {
-    use HandlesOwnErrorTestCases;
+    use HandlesOwnErrorsTestCases;
     use ValidationTestTrait;
 
     /**

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -6,7 +6,7 @@ namespace Firehed\API\Traits;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
-trait HandlesOwnErrorTestCases
+trait HandlesOwnErrorsTestCases
 {
     private $handleExceptionMayRethrow = false;
 

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace Firehed\API\Traits;
 
+use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
 trait HandlesOwnErrorsTestCases
 {
     private $handleExceptionMayRethrow = false;
+
+    abstract protected function getEndpoint(): HandlesOwnErrorsInterface;
 
     public function setAllowHandleExceptionToRethrow(bool $allowed)
     {
@@ -21,8 +24,8 @@ trait HandlesOwnErrorsTestCases
      */
     public function testHandleException(Throwable $e)
     {
-        $response = $this->getEndpoint()->handleException($e);
         try {
+            $response = $this->getEndpoint()->handleException($e);
             $this->assertInstanceOf(
                 ResponseInterface::class,
                 $response,
@@ -77,7 +80,7 @@ trait HandlesOwnErrorsTestCases
             // PHP7: Add new Error exceptions
             [new \Error()],
                 [new \ArithmeticError()],
-                [new \AssertionError()],
+                // [new \AssertionError()],
                 [new \DivisionByZeroError()],
                 [new \ParseError()],
                 [new \TypeError()],

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -80,7 +80,7 @@ trait HandlesOwnErrorsTestCases
             // PHP7: Add new Error exceptions
             [new \Error()],
                 [new \ArithmeticError()],
-                // [new \AssertionError()],
+                [new \AssertionError()],
                 [new \DivisionByZeroError()],
                 [new \ParseError()],
                 [new \TypeError()],

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -15,6 +15,7 @@ use Throwable;
  * @covers Firehed\API\Traits\EndpointTestCases::getValidation
  * @covers Firehed\API\Traits\EndpointTestCases::testGetUri
  * @covers Firehed\API\Traits\EndpointTestCases::testGetMethod
+ * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
  */
 class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -15,7 +15,6 @@ use Throwable;
  * @covers Firehed\API\Traits\EndpointTestCases::getValidation
  * @covers Firehed\API\Traits\EndpointTestCases::testGetUri
  * @covers Firehed\API\Traits\EndpointTestCases::testGetMethod
- * @covers Firehed\API\Traits\EndpointTestCases::testHandleException
  */
 class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Traits/HandlesOwnErrorsTestCasesTest.php
+++ b/tests/Traits/HandlesOwnErrorsTestCasesTest.php
@@ -31,6 +31,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::setAllowHandleExceptionToRethrow
      * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
      * @dataProvider exceptionsToHandle
      */
@@ -39,5 +40,14 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
         $this->setAllowHandleExceptionToRethrow(false);
         $this->expectException(get_class($e));
         $this->testHandleException($e);
+    }
+
+    /**
+     * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
+     */
+    public function testRedundantlyBecauseTraitApplicationIsWierd()
+    {
+        $ex = new \Exception();
+        $this->testHandleException($ex);
     }
 }

--- a/tests/Traits/HandlesOwnErrorsTestCasesTest.php
+++ b/tests/Traits/HandlesOwnErrorsTestCasesTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\API\Traits;
+
+use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
+use Throwable;
+
+/**
+ * @coversDefaultClass Firehed\API\EndpointFixture
+ * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::<protected>
+ * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::<private>
+ */
+class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
+{
+    use HandlesOwnErrorsTestCases;
+
+    public function setUp()
+    {
+        $this->setAllowHandleExceptionToRethrow(true);
+    }
+
+    protected function getEndpoint(): HandlesOwnErrorsInterface
+    {
+        $mock = $this->createMock(HandlesOwnErrorsInterface::class);
+        $mock->method('handleException')
+            ->willReturnCallback(function ($e) {
+                throw $e;
+            });
+        return $mock;
+    }
+
+    /**
+     * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
+     * @dataProvider exceptionsToHandle
+     */
+    public function testDefaultHandling(Throwable $e)
+    {
+        $this->setAllowHandleExceptionToRethrow(false);
+        $this->expectException(get_class($e));
+        $this->testHandleException($e);
+    }
+}


### PR DESCRIPTION
The main goal of this is to make it easy to implement `handleException` in v3.1 as a no-op rethrow without causing all of the trait-added tests to fail.