### PR TITLE
Rewrite incoming RequestInterface into ServerRequestInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Overhauled authentication (#43)
 - Overhauled error handling (#37, #38, #63)
 - Added support for PSR-15 Middleware (#59)
+
 ### Changed
 - Internal refactoring
 - Deprecate use of base RequestInterface (#48)
+- If a RequestInterface object is provided to the dispatcher, it will be internally converted to a ServerRequestInterface to ensure compatibility with Middleware and error handling.
+  Relying on this functionality is deprecated from the start, **highly** discouraged, and may be imperfect.
 
 ## [3.0.6] - 2018-04-30
 ### Changed

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
-use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\ServerRequestFactory;
 
 class Dispatcher implements RequestHandlerInterface
 {
@@ -154,15 +154,14 @@ class Dispatcher implements RequestHandlerInterface
 
     private function transformRequestToServerRequest(RequestInterface $request): ServerRequestInterface
     {
-        $sri = new ServerRequest(
-            [],
-            [],
-            $request->getUri(),
-            $request->getMethod(),
-            $request->getBody(),
-            $request->getHeaders()
-        );
-        return $sri;
+        $serverRequest = ServerRequestFactory::fromGlobals()
+            ->withUri($request->getUri())
+            ->withMethod($request->getMethod())
+            ->withBody($request->getBody());
+        foreach ($request->getHeaders() as $name => $values) {
+            $serverRequest = $serverRequest->withHeader($name, $values);
+        }
+        return $serverRequest;
     }
 
     /**

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -234,21 +234,14 @@ class Dispatcher implements RequestHandlerInterface
         $request = $this->request;
 
         // Delegate to PSR-15 middleware when possible
-        if ($request instanceof ServerRequestInterface) {
-            return $this->handle($request);
-        }
-        // If legacy ResponseInterace only, do not even try
-        return $this->doDispatch($request);
+        return $this->handle($request);
     }
 
-    private function doDispatch(RequestInterface $request)
+    private function doDispatch(ServerRequestInterface $request)
     {
-        $isSRI = $request instanceof ServerRequestInterface;
-
         $endpoint = $this->getEndpoint($request);
         try {
-            if ($isSRI
-                && $this->authenticationProvider
+            if ($this->authenticationProvider
                 && $endpoint instanceof Interfaces\AuthenticatedEndpointInterface
             ) {
                 $auth = $this->authenticationProvider->authenticate($request);
@@ -273,7 +266,7 @@ class Dispatcher implements RequestHandlerInterface
                 // If an application-wide handler has been defined, use the
                 // response that it generates. If not, just rethrow the
                 // exception for the system default (if defined) to handle.
-                if ($this->error_handler && $isSRI) {
+                if ($this->error_handler) {
                     $response = $this->error_handler->handle($request, $e);
                 } else {
                     throw $e;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -19,6 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
+use Zend\Diactoros\ServerRequest;
 
 class Dispatcher implements RequestHandlerInterface
 {
@@ -145,9 +146,23 @@ class Dispatcher implements RequestHandlerInterface
                 ),
                 E_USER_DEPRECATED
             );
+            $request = $this->transformRequestToServerRequest($request);
         }
         $this->request = $request;
         return $this;
+    }
+
+    private function transformRequestToServerRequest(RequestInterface $request): ServerRequestInterface
+    {
+        $sri = new ServerRequest(
+            [],
+            [],
+            $request->getUri(),
+            $request->getMethod(),
+            $request->getBody(),
+            $request->getHeaders()
+        );
+        return $sri;
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -10,19 +10,17 @@ use Firehed\API\Authorization;
 use Firehed\API\Interfaces\EndpointInterface;
 use Firehed\API\Interfaces\ErrorHandlerInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
-use Throwable;
-
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-
+use Throwable;
 use Zend\Diactoros\Request;
-use Zend\Diactoros\Stream;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Stream;
 
 /**
  * @coversDefaultClass Firehed\API\Dispatcher
@@ -161,9 +159,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             'GET',
             ['shortstring' => 'aBcD']
         );
-        // $body = $req->getBody();
-        // $body->write('shortstring=aBcD');
-        // $req = $req->withBody($body);
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -96,6 +96,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $req = $this->createMock(RequestInterface::class);
         $req->method('getHeaders')->willReturn([]);
         $req->method('getBody')->willReturn($this->createMock(StreamInterface::class));
+        $req->method('getUri')->willReturn($this->createMock(UriInterface::class));
         $this->assertSame(
             $d,
             $d->setRequest($req),
@@ -283,6 +284,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             })
             ->addResponseMiddleware(function ($response, $next) {
                 // This should never hit
+                $this->fail('should be unreachable');
                 $this->response_hits = 'b';
                 return $next($response);
             })

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -13,11 +13,16 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Throwable;
 
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+
+use Zend\Diactoros\Request;
+use Zend\Diactoros\Stream;
+use Zend\Diactoros\ServerRequest;
 
 /**
  * @coversDefaultClass Firehed\API\Dispatcher
@@ -89,6 +94,8 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         $d = new Dispatcher();
         $req = $this->createMock(RequestInterface::class);
+        $req->method('getHeaders')->willReturn([]);
+        $req->method('getBody')->willReturn($this->createMock(StreamInterface::class));
         $this->assertSame(
             $d,
             $d->setRequest($req),
@@ -116,13 +123,11 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         // See tests/EndpointFixture
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
-        $req->expects($this->any())
-            ->method('getBody')
-            ->will($this->returnValue('shortstring=aBcD'));
-        $req->expects($this->any())
-            ->method('getHeader')
-            ->with('Content-type')
-            ->will($this->returnValue(['application/x-www-form-urlencoded']));
+        $body = $req->getBody();
+        $body->write('shortstring=aBcD');
+        $req = $req->withBody($body);
+        $req = $req->withHeader('Content-type', 'application/x-www-form-urlencoded');
+
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
@@ -155,8 +160,9 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             'GET',
             ['shortstring' => 'aBcD']
         );
-        $req->method('getBody')
-            ->will($this->returnValue('shortstring=aBcD'));
+        // $body = $req->getBody();
+        // $body->write('shortstring=aBcD');
+        // $req = $req->withBody($body);
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
@@ -451,13 +457,10 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         // See tests/EndpointFixture
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
-        $req->expects($this->any())
-            ->method('getBody')
-            ->will($this->returnValue('shortstring=thisistoolong'));
-        $req->expects($this->any())
-            ->method('getHeader')
-            ->with('Content-type')
-            ->will($this->returnValue(['application/x-www-form-urlencoded']));
+        $body = $req->getBody();
+        $body->write('shortstring=thisistoolong');
+        $req = $req->withBody($body);
+        $req = $req->withHeader('Content-type', 'application/x-www-form-urlencoded');
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
@@ -474,10 +477,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     public function testUnsupportedContentTypeReachesErrorHandler()
     {
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
-        $req->expects($this->any())
-            ->method('getHeader')
-            ->with('Content-type')
-            ->will($this->returnValue(['application/x-test-failure']));
+        $req = $req->withHeader('Content-type', 'application/x-test-failure');
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
             ->setParserList($this->getDefaultParserList())
@@ -496,10 +496,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         $contentType = 'application/json; charset=utf-8';
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
-        $req->expects($this->any())
-            ->method('getHeader')
-            ->with('Content-type')
-            ->will($this->returnValue([$contentType]));
+        $req = $req->withHeader('Content-type', $contentType);
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
             ->setParserList($this->getDefaultParserList())
@@ -593,42 +590,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->with($e)
             ->will($this->throwException($e));
         $this->executeMockRequestOnEndpoint($endpoint, $dispatcher, ServerRequestInterface::class);
-    }
-
-    /**
-     * This is a sort of BC-prevention test: in v4, the Dispatcher will only
-     * accept a ServerRequestInterface instead of the base-level
-     * RequestInterface. The new error handler is typehinted as such. This
-     * checks that if the base class was provided to the dispatcher, it
-     * shouldn't attempt to use the error handler since it would just result in
-     * a TypeError. This will be removed in v4.
-     *
-     * @covers ::dispatch
-     */
-    public function testExceptionsLeakWhenRequestIsBaseClass()
-    {
-        $e = new Exception('This should reach the top level');
-
-        $handler = $this->createMock(ErrorHandlerInterface::class);
-        $handler->expects($this->never())
-            ->method('handle');
-
-        $dispatcher = new Dispatcher();
-        $dispatcher->setErrorHandler($handler);
-
-        $endpoint = $this->getMockEndpoint();
-        $endpoint->method('execute')
-            ->will($this->throwException($e));
-        $endpoint->expects($this->once())
-            ->method('handleException')
-            ->with($e)
-            ->will($this->throwException($e));
-        try {
-            $this->executeMockRequestOnEndpoint($endpoint, $dispatcher);
-            $this->fail('An exception should have been thrown');
-        } catch (Throwable $t) {
-            $this->assertSame($e, $t);
-        }
     }
 
     /** @covers ::dispatch */
@@ -925,7 +886,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @param string $method optional HTTP method
      * @param array $query_data optional raw, unescaped query string data
      * @param string $requestClass What RequestInterface to mock
-     * @return RequestInterface | \PHPUnit\Framework\MockObject\MockObject
+     * @return RequestInterface
      */
     private function getMockRequestWithUriPath(
         string $uri,
@@ -933,6 +894,22 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         array $query_data = [],
         string $requestClass = RequestInterface::class
     ): RequestInterface {
+        if ($requestClass === RequestInterface::class) {
+            $request = new Request(
+                $uri.'?'.http_build_query($query_data),
+                $method
+            );
+        } elseif ($requestClass === ServerRequestInterface::class) {
+            $request = new ServerRequest(
+                [],
+                [],
+                $uri,
+                $method
+            );
+        } else {
+            throw new \Exception('Invalid request class');
+        }
+        return $request;
         $mock_uri = $this->createMock(UriInterface::class);
         $mock_uri->expects($this->any())
             ->method('getPath')


### PR DESCRIPTION
This needs way more testing, but isn't overly complex. Instead of a bunch of switching and fallback logic, just build on the immutability of PSR-7 messages to translate an incoming RequestInterface into a ServerRequestInterface.

Rather than empty arrays, this should blast in `$_SERVER`, `$_FILES`, `$_GET`, `$_COOKIE`. ParsedBody should do... something.