### PR TITLE
Search for endpoint inside try to allow failures to reach handler

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -230,8 +230,10 @@ class Dispatcher implements RequestHandlerInterface
     {
         $isSRI = $request instanceof ServerRequestInterface;
 
-        $endpoint = $this->getEndpoint($request);
+        /** @var ?EndpointInterface */
+        $endpoint = null;
         try {
+            $endpoint = $this->getEndpoint($request);
             if ($isSRI
                 && $this->authenticationProvider
                 && $endpoint instanceof Interfaces\AuthenticatedEndpointInterface


### PR DESCRIPTION
This generally fixes #27, allowing a routing failure to reach the application-level error handler. Without this you are _forced_ to use a different fallback handler in the front controller (or in some other way modify it)