### PR TITLE
Rename Interfaces\ErrorHandlerInterface to Errors\HandlerInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Other auto-detected container entries:
 | Psr\Log\LoggerInterface | Internal logging | generated front controller |
 | Firehed\API\Authentication\ProviderInterface | Authentication Provider | Always if an AuthorizationProvider is set |
 | Firehed\API\Authorization\ProviderInterface | Authorization Provider | Always if an AuthenticationProvider is set |
-| Firehed\API\Interfaces\ErrorHandlerInterface | Error Handler | Always |
+| Firehed\API\Errors\HandlerInterface | Error Handler | Always |
 
 
 ### Example
@@ -160,7 +160,7 @@ The API framework is responsible for catching all exceptions thrown during an En
 All endpoints that implement `Firehed\API\Interfaces\HandlesOwnErrorsInterface` (which is a part of `EndpointInterface` prior to v4.0.0) will have their `handleException()` method called with the thrown exception.
 This method _may_ choose to ignore certain exception classes (by rethrowing them), but must return a PSR `ResponseInterface` when opting to handle an exception.
 
-Starting in v3.1.0, error handling can be implemeneted globally by providing a `Firehed\API\Interfaces\ErrorHandlerInterface` to the Dispatcher via `setErrorHandler()`.
+Starting in v3.1.0, error handling can be implemeneted globally by providing a `Firehed\API\Errors\HandlerInterface` to the Dispatcher via `setErrorHandler()`.
 This is functionally identical to `HandlesOwnErrorInterface` described above, with the addition that the PSR `ServerRequestInterface` will also be available (primarily so that the response can be formatted appropriately for the request, e.g. based on the `Accept` header).
 
 Finally, a global fallback handler is configured by default, which will log the exception and return a generic 500 error.

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,7 +6,7 @@ namespace Firehed\API;
 
 use BadMethodCallException;
 use DomainException;
-use Firehed\API\Interfaces\ErrorHandlerInterface;
+use Firehed\API\Errors\HandlerInterface;
 use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
 use Firehed\Common\ClassMapper;
 use Firehed\Input\Containers\ParsedInput;
@@ -108,8 +108,8 @@ class Dispatcher implements RequestHandlerInterface
         }
 
         // Auto-detect error handler
-        if (!$this->error_handler && $container->has(ErrorHandlerInterface::class)) {
-            $this->setErrorHandler($container->get(ErrorHandlerInterface::class));
+        if (!$this->error_handler && $container->has(HandlerInterface::class)) {
+            $this->setErrorHandler($container->get(HandlerInterface::class));
         }
 
         return $this;
@@ -119,10 +119,10 @@ class Dispatcher implements RequestHandlerInterface
      * Provide a default error handler. This will be used in the event that an
      * endpoint does not define its own handler.
      *
-     * @param ErrorHandlerInterface $handler
+     * @param HandlerInterface $handler
      * @return self
      */
-    public function setErrorHandler(ErrorHandlerInterface $handler): self
+    public function setErrorHandler(HandlerInterface $handler): self
     {
         $this->error_handler = $handler;
         return $this;

--- a/src/Errors/HandlerInterface.php
+++ b/src/Errors/HandlerInterface.php
@@ -7,6 +7,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
+/**
+ * Implementations of this interface are for application-wide error handling.
+ * See the section on error handling in the README for additional information.
+ */
 interface HandlerInterface
 {
     /**

--- a/src/Errors/HandlerInterface.php
+++ b/src/Errors/HandlerInterface.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace Firehed\API\Interfaces;
+namespace Firehed\API\Errors;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
-interface ErrorHandlerInterface
+interface HandlerInterface
 {
     /**
      * Handle an exception for the given request. It is RECOMMENDED that

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -8,7 +8,7 @@ use Exception;
 use Firehed\API\Authentication;
 use Firehed\API\Authorization;
 use Firehed\API\Interfaces\EndpointInterface;
-use Firehed\API\Interfaces\ErrorHandlerInterface;
+use Firehed\API\Errors\HandlerInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -573,7 +573,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             return $res;
         };
 
-        $handler = $this->createMock(ErrorHandlerInterface::class);
+        $handler = $this->createMock(HandlerInterface::class);
         $handler->expects($this->once())
             ->method('handle')
             ->will($this->returnCallback($cb));
@@ -609,7 +609,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         $e = new Exception('This should reach the top level');
 
-        $handler = $this->createMock(ErrorHandlerInterface::class);
+        $handler = $this->createMock(HandlerInterface::class);
         $handler->expects($this->never())
             ->method('handle');
 
@@ -729,7 +729,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     public function testErrorHandlerIsAutoDetected()
     {
         $ex = new Exception('execute');
-        $eh = $this->createMock(ErrorHandlerInterface::class);
+        $eh = $this->createMock(HandlerInterface::class);
         $eh->expects($this->once())
             ->method('handle')
             ->will($this->returnCallback(function ($sri, $caught) use ($ex) {
@@ -745,7 +745,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             });
 
         $container = $this->getMockContainer([
-            ErrorHandlerInterface::class => $eh,
+            HandlerInterface::class => $eh,
             'ClassThatDoesNotExist' => $ep,
         ]);
         $req = $this->getMockRequestWithUriPath('/c', 'GET', [], ServerRequestInterface::class);


### PR DESCRIPTION
This just aims to make the naming a bit more sensible before landing it in a tagged release.