### PR TITLE
Deprecate the BearerToken trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecate use of base RequestInterface (#48)
 - If a RequestInterface object is provided to the dispatcher, it will be internally converted to a ServerRequestInterface to ensure compatibility with Middleware and error handling.
   Relying on this functionality is deprecated from the start, **highly** discouraged, and may be imperfect.
+- Deprecated the `BearerToken` authentication trait
 
 ## [3.0.6] - 2018-04-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Internal refactoring
+
+### Deprecated
 - Deprecate use of base RequestInterface (#48)
 - If a RequestInterface object is provided to the dispatcher, it will be internally converted to a ServerRequestInterface to ensure compatibility with Middleware and error handling.
   Relying on this functionality is deprecated from the start, **highly** discouraged, and may be imperfect.

--- a/src/Traits/Authentication/BearerToken.php
+++ b/src/Traits/Authentication/BearerToken.php
@@ -17,6 +17,9 @@ use RuntimeException;
  * itself, since it's unaware of the application at large. This just parses the
  * HTTP request and extracts the bearer token, handling invalid or missing
  * values. Provide said handler with `setHandleBearerTokenCallback()`.
+ *
+ * @deprecated - this will be removed in 4.0.0, in favor of the new
+ * authenticaton and authorization tools.
  */
 trait BearerToken
 {
@@ -25,6 +28,10 @@ trait BearerToken
 
     public function authenticate(RequestInterface $request): EndpointInterface
     {
+        trigger_error(
+            'BearerToken will be removed in 4.0.0. Use the new authentication tools instead.',
+            \E_USER_DEPRECATED
+        );
         if (!$this->handleBearerTokenCallback) {
             throw new BadMethodCallException(
                 'There is no callback to handle the Bearer token. Call '.

--- a/tests/Traits/Authentication/BearerTokenTest.php
+++ b/tests/Traits/Authentication/BearerTokenTest.php
@@ -21,6 +21,19 @@ class BearerTokenTest extends \PHPUnit\Framework\TestCase
     private $calledWithEndpoint;
     private $calledWithToken;
 
+    private $reporting;
+
+    public function setUp()
+    {
+        $this->reporting = error_reporting();
+        error_reporting($this->reporting & ~E_USER_DEPRECATED);
+    }
+
+    public function tearDown()
+    {
+        error_reporting($this->reporting);
+    }
+
     /**
      * @covers ::authenticate
      * @covers ::setHandleBearerTokenCallback


### PR DESCRIPTION
This may resurface as a new trait in the context of the new auth tools, but it doesn't make sense to keep this around.