### PR TITLE
Allow Diactoros 1.3 or 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.1] - 2018-10-24
+### Summary
+- Widen range of supported Zend Diactoros version
+
 ## [3.2.0] - 2018-09-19
 ### Summary
 - Added support for `PATCH` HTTP method

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3 || ^2.0"
     },
     "suggest": {
         "firehed/inputobjects": "Pre-made Input components for validation"

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -161,6 +161,8 @@ class Dispatcher implements RequestHandlerInterface
         foreach ($request->getHeaders() as $name => $values) {
             $serverRequest = $serverRequest->withHeader($name, $values);
         }
+        // ZD2 hints the return type of withHeader to MessageInterface not SRI
+        assert($serverRequest instanceof ServerRequestInterface);
         return $serverRequest;
     }
 

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -92,6 +92,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     {
         $d = new Dispatcher();
         $req = $this->createMock(RequestInterface::class);
+        $req->method('getMethod')->willReturn('GET');
         $req->method('getHeaders')->willReturn([]);
         $req->method('getBody')->willReturn($this->createMock(StreamInterface::class));
         $req->method('getUri')->willReturn($this->createMock(UriInterface::class));


### PR DESCRIPTION
Will allow consumers of the API framework to use either version