### PR TITLE
Allow Diactoros 1.3 or 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `Traits\PostRequest`
 - `Traits\PutRequest`
 
+## [3.2.1] - 2018-10-24
+### Summary
+- Widen range of supported Zend Diactoros version
+
 ## [3.2.0] - 2018-09-19
 ### Summary
 - Added support for `PATCH` HTTP method

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.0",
         "symfony/console": "^3 || ^4",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3 || ^2.0"
     },
     "suggest": {
         "firehed/inputobjects": "Pre-made Input components for validation"


### PR DESCRIPTION
Will allow consumers of the API framework to use either version