### PR TITLE
Drop Arcanist integration

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,8 +1,0 @@
-{
-    "phabricator.uri": "https://phabricator.ericstern.com",
-    "unit.engine": "Firehed\\Arctools\\Unit\\PHPUnitTestEngine",
-    "unit.phpunit.binary": "vendor/bin/phpunit",
-    "load": [
-        "vendor/firehed/arctools/src"
-    ]
-}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
       "sort-packages": true
     },
     "require-dev": {
-        "firehed/arctools": "^1.0",
         "phpstan/phpstan": "^0.9.2",
         "phpstan/phpstan-phpunit": "^0.9.4",
         "phpunit/phpunit": "^6.0 | ^7.0",


### PR DESCRIPTION
All development is happening on Github, so it no longer makes sense to keep this around.