### PR TITLE
Fix numerous tooling issues in PHP7.4, largely around PHPStan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /build/
 __*__.*
 .apiconfig
+.phpunit.result.cache
 # Ignored since this is a library
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 7.4-snapshot
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 7.4-snapshot
+  - 7.4snapshot
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 env:
   matrix:
     - DEPENDENCIES="high"
-    - DEPENDENCIES="low"
+    # - DEPENDENCIES="low"
   global:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
       ],
       "autofix": "phpcbf src tests",
       "phpunit": "phpunit",
-      "phpstan": "phpstan analyse --no-progress -c phpstan.neon -l8 src tests",
+      "phpstan": "phpstan analyse --no-progress .",
       "phpcs": "phpcs src tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
       }
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.9.2",
-        "phpstan/phpstan-phpunit": "^0.9.4",
-        "phpunit/phpunit": "^7.5.0 || ^8.0",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.3.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
       ],
       "autofix": "phpcbf src tests",
       "phpunit": "phpunit",
-      "phpstan": "phpstan analyse --no-progress -c phpstan.neon -l7 src tests",
+      "phpstan": "phpstan analyse --no-progress -c phpstan.neon -l8 src tests",
       "phpcs": "phpcs src tests"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,32 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
+			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Method Firehed\\\\API\\\\ConfigTest\\:\\:constructProvider\\(\\) should return array\\<array\\<string\\>\\> but returns array\\<int, array\\<int, array\\<string, string\\>\\|class\\-string\\>\\>\\.$#"
+			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
+			count: 1
+			path: tests/ContainerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$originalClassName of method PHPUnit\\\\Framework\\\\TestCase\\:\\:createMock\\(\\) expects class\\-string\\<mixed\\>, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/DispatcherTest.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:createMock\\(\\)$#"
+			count: 1
+			path: tests/DispatcherTest.php
+
+		-
+			message: "#^Function xdebug_get_headers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/xdebug_get_headers.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,6 @@ includes:
 parameters:
     ignoreErrors:
         - '#Call to method setInterface\(\) on an unknown class Firehed\\Common\\this#'
+    excludes_analyse:
+        - vendor
+    level: 8

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
 parameters:
     ignoreErrors:

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,8 +30,12 @@ class Config implements ContainerInterface
         self::KEY_SOURCE,
     ];
 
+    /** @var array<string, string> */
     private $data = [];
 
+    /**
+     * @param array<string, string> $params
+     */
     public function __construct(array $params)
     {
         foreach (self::REQUIRED_PARAMS as $param) {
@@ -75,6 +79,7 @@ class Config implements ContainerInterface
             throw new RuntimeException('Config file not readable');
         }
         $json = file_get_contents($file);
+        assert($json !== false);
         $data = json_decode($json, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new RuntimeException('Config file contained invalid JSON');
@@ -83,7 +88,7 @@ class Config implements ContainerInterface
         return new Config($data);
     }
 
-    private function validateContainer()
+    private function validateContainer(): void
     {
         if (!$this->has(self::KEY_CONTAINER)) {
             return;

--- a/src/Console/CompileAll.php
+++ b/src/Console/CompileAll.php
@@ -25,13 +25,13 @@ class CompileAll extends Command
         $this->config = $config;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('compile:all')
             ->setDescription('Build required static resources');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $logger = new ConsoleLogger($output);
 
@@ -65,5 +65,6 @@ class CompileAll extends Command
             'Wrote parser map to %s',
             Dispatcher::PARSER_LIST
         ));
+        return 0;
     }
 }

--- a/src/Console/GenerateConfig.php
+++ b/src/Console/GenerateConfig.php
@@ -15,15 +15,16 @@ use Symfony\Component\Console\Question\Question;
 
 class GenerateConfig extends Command
 {
+    /** @var QuestionHelper */
     private $questionHelper;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('generate:config')
             ->setDescription('Generate an api config file');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->questionHelper = new QuestionHelper();
 
@@ -37,7 +38,7 @@ class GenerateConfig extends Command
             );
             if (!$this->questionHelper->ask($input, $output, $overwriteQ)) {
                 $output->writeln('Exiting.');
-                return;
+                return 1;
             }
         }
 
@@ -81,6 +82,7 @@ class GenerateConfig extends Command
         $json = json_encode($config, JSON_PRETTY_PRINT);
         file_put_contents(Config::FILENAME, $json);
         $output->writeln('Wrote config file');
+        return 0;
     }
 
     private function askWithDefault(
@@ -127,6 +129,7 @@ class GenerateConfig extends Command
 
         $autoload = $data['autoload']['psr-4'];
         $namespace = array_keys($autoload)[0];
+        assert(is_string($namespace));
 
         $autoloadBase = $autoload[$namespace];
         // Autoloading can split a NS into multiple directories, grab the first

--- a/src/Console/GenerateConfig.php
+++ b/src/Console/GenerateConfig.php
@@ -118,7 +118,9 @@ class GenerateConfig extends Command
             return '';
         }
 
-        $data = json_decode(file_get_contents('composer.json'), true);
+        $composer = file_get_contents('composer.json');
+        assert($composer !== false);
+        $data = json_decode($composer, true);
         if (!$data) {
             return '';
         }

--- a/src/Console/GenerateEndpoint.php
+++ b/src/Console/GenerateEndpoint.php
@@ -31,7 +31,7 @@ class GenerateEndpoint extends Command
         $this->config = $config;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('generate:endpoint')
             ->setDescription('Generate skeleton code for a new endpoint')
@@ -39,7 +39,7 @@ class GenerateEndpoint extends Command
             ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $verbosityLevelMap = [
             LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
@@ -84,6 +84,7 @@ class GenerateEndpoint extends Command
         ]);
 
         $this->writeFile($destination, $rendered, $input, $output);
+        return 0;
     }
 
     private function getPathForFQCN(string $fqcn, string $sourceDir): string
@@ -97,6 +98,7 @@ class GenerateEndpoint extends Command
             throw new RuntimeException('composer.json not found or not readable');
         }
         $composerJson = file_get_contents('composer.json');
+        assert($composerJson !== false);
         $composerConfig = json_decode($composerJson, true);
         if (!isset($composerConfig['autoload']['psr-4'])) {
             throw new RuntimeException('Only PSR-4 autoload definitions can be '
@@ -140,11 +142,12 @@ class GenerateEndpoint extends Command
      * components.
      *
      * @param string $fqcn
-     * @return array [namespace, class]
+     * @return array<string> [namespace, class]
      */
     private function parseFQCN(string $fqcn): array
     {
         $last = strrpos($fqcn, '\\');
+        assert($last !== false);
         return [
             substr($fqcn, 0, $last),
             substr($fqcn, $last + 1),
@@ -156,7 +159,7 @@ class GenerateEndpoint extends Command
         string $contents,
         InputInterface $input,
         OutputInterface $output
-    ) {
+    ): void {
         if (file_exists($filename)) {
             throw new RuntimeException('File already exists');
         }

--- a/src/Console/GenerateEndpoint.php
+++ b/src/Console/GenerateEndpoint.php
@@ -48,6 +48,7 @@ class GenerateEndpoint extends Command
         $logger = new ConsoleLogger($output, $verbosityLevelMap);
 
         $relativePath = $input->getArgument(self::ARGUMENT_PATH);
+        assert(is_string($relativePath));
         $normalizedPath = str_replace('\\', '/', $relativePath);
         $logger->debug('Building endpoint for {path}', [
             'path' => $normalizedPath,
@@ -67,6 +68,7 @@ class GenerateEndpoint extends Command
 
         $template = file_get_contents(__DIR__.'/'.self::TEMPLATE_FILE);
 
+        assert($template !== false);
         $rendered = sprintf(
             $template,
             $namespace,
@@ -125,6 +127,7 @@ class GenerateEndpoint extends Command
                     $relative = substr($fqcn, strlen($prefix));
                     $dest = sprintf('%s/%s.php', $path, $relative);
                     // This is a bit of path munging
+                    /** @var string */
                     return preg_replace(
                         '#/{2,}#',
                         DIRECTORY_SEPARATOR,

--- a/src/Console/GenerateFrontController.php
+++ b/src/Console/GenerateFrontController.php
@@ -25,14 +25,14 @@ class GenerateFrontController extends Command
         $this->config = $config;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('generate:frontController')
             ->setDescription('Generate the default front-contoller')
             ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $verbosityLevelMap = [
             LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
@@ -51,6 +51,7 @@ class GenerateFrontController extends Command
         $webroot = $this->config->get(Config::KEY_WEBROOT);
 
         $template = file_get_contents(__DIR__.'/'.self::TEMPLATE_FILE);
+        assert($template !== false);
         $frontController = sprintf(
             $template,
             $this->resolveRelativeProjectRoot($webroot),
@@ -66,9 +67,10 @@ class GenerateFrontController extends Command
         $logger->info('Wrote front controller to {path}', [
             'path' => $path,
         ]);
+        return 0;
     }
 
-    private function resolveRelativeProjectRoot(string $webroot)
+    private function resolveRelativeProjectRoot(string $webroot): string
     {
         $dirs = explode('/', $webroot);
         return str_repeat('/..', count($dirs));

--- a/src/Container.php
+++ b/src/Container.php
@@ -11,9 +11,10 @@ use Psr\Container as Psr;
  */
 class Container implements Psr\ContainerInterface
 {
-    /** @var array */
+    /** @var array<string, mixed> */
     private $data;
 
+    /** @param array<string, mixed> $data */
     public function __construct(array $data)
     {
         $this->data = $data;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -24,11 +24,22 @@ class Dispatcher implements RequestHandlerInterface
     const ENDPOINT_LIST = '__endpoint_list__.php';
     const PARSER_LIST = '__parser_list__.php';
 
+    /** @var ?ContainerInterface */
     private $container;
+
+    /** @var bool */
     private $containerHasAuthProviders = false;
+
+    /** @var bool */
     private $containerHasErrorHandler = false;
+
+    /** @var string | string[] */
     private $endpointList = self::ENDPOINT_LIST;
+
+    /** @var string | string[] */
     private $parserList = self::PARSER_LIST;
+
+    /** @var MiddlewareInterface[] */
     private $psrMiddleware = [];
 
     /**
@@ -80,7 +91,7 @@ class Dispatcher implements RequestHandlerInterface
      *
      * @internal Overrides the standard parser list. Used primarily for unit
      * testing.
-     * @param array|string $parserList The parser list or its path
+     * @param string | string[] $parserList The parser list or its path
      * @return self
      */
     public function setParserList($parserList): self
@@ -97,7 +108,7 @@ class Dispatcher implements RequestHandlerInterface
      *
      * @internal Overrides the standard endpoint list. Used primarily for unit
      * testing.
-     * @param array|string $endpointList The endpoint list or its path
+     * @param string | string[] $endpointList The endpoint list or its path
      * @return self
      */
     public function setEndpointList($endpointList): self
@@ -122,10 +133,10 @@ class Dispatcher implements RequestHandlerInterface
      * Execute the request
      *
      * @param ServerRequestInterface $request The request to process
-     * @throws TypeError if both execute and handleException have bad return
+     * @throws \TypeError if both execute and handleException have bad return
      * types
-     * @throws LogicException if the dispatcher is misconfigured
-     * @throws RuntimeException on 404-type errors
+     * @throws \LogicException if the dispatcher is misconfigured
+     * @throws \RuntimeException on 404-type errors
      * @return ResponseInterface the completed HTTP response
      */
     public function dispatch(ServerRequestInterface $request): ResponseInterface
@@ -137,7 +148,7 @@ class Dispatcher implements RequestHandlerInterface
 
     private function doDispatch(ServerRequestInterface $request): ResponseInterface
     {
-        /** @var ?EndpointInterface */
+        /** @var ?Interfaces\EndpointInterface */
         $endpoint = null;
         try {
             [$fqcn, $uriData] = (new ClassMapper($this->endpointList))
@@ -154,6 +165,7 @@ class Dispatcher implements RequestHandlerInterface
             if ($this->containerHasAuthProviders
                 && $endpoint instanceof Interfaces\AuthenticatedEndpointInterface
             ) {
+                assert($this->container !== null); // hasAuthProviders guarantees this
                 $auth = $this->container
                     ->get(Authentication\ProviderInterface::class)
                     ->authenticate($request);
@@ -180,6 +192,7 @@ class Dispatcher implements RequestHandlerInterface
                 // response that it generates. If not, just rethrow the
                 // exception for the system default (if defined) to handle.
                 if ($this->containerHasErrorHandler) {
+                    assert($this->container !== null); // hasAuthProviders guarantees this
                     $response = $this->container
                         ->get(HandlerInterface::class)
                         ->handle($request, $e);

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -108,7 +108,7 @@ class Dispatcher implements RequestHandlerInterface
      *
      * @internal Overrides the standard endpoint list. Used primarily for unit
      * testing.
-     * @param string | string[] $endpointList The endpoint list or its path
+     * @param string | string[][] $endpointList The endpoint list or its path
      * @return self
      */
     public function setEndpointList($endpointList): self

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -33,7 +33,7 @@ class Dispatcher implements RequestHandlerInterface
     /** @var bool */
     private $containerHasErrorHandler = false;
 
-    /** @var string | string[] */
+    /** @var string | string[][] */
     private $endpointList = self::ENDPOINT_LIST;
 
     /** @var string | string[] */

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -22,13 +22,19 @@ class ErrorHandler
         $this->logger = $logger;
     }
 
-    public function handleThrowable(Throwable $t)
+    public function handleThrowable(Throwable $t): void
     {
         header('HTTP/1.1 500 Internal Server Error');
         $this->logger->error((string) $t);
     }
 
-    public function handleError($severity, $message, $file, $line)
+    /**
+     * @param int $severity
+     * @param string $message
+     * @param string $file
+     * @param int $line
+     */
+    public function handleError($severity, $message, $file, $line): void
     {
         if (error_reporting() & $severity) {
             throw new ErrorException($message, 0, $severity, $file, $line);

--- a/src/Interfaces/AuthenticatedEndpointInterface.php
+++ b/src/Interfaces/AuthenticatedEndpointInterface.php
@@ -7,5 +7,5 @@ use Psr\Container\ContainerInterface;
 
 interface AuthenticatedEndpointInterface extends EndpointInterface
 {
-    public function setAuthentication(ContainerInterface $auth);
+    public function setAuthentication(ContainerInterface $auth): void;
 }

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -23,9 +23,9 @@ class MiddlewareDispatcher implements RequestHandlerInterface
     private $fallback;
 
     /**
-     * @var RequestHandlerInterface $fallback The default handler to call once
+     * @param RequestHandlerInterface $fallback The default handler to call once
      * all middleware is exhausted
-     * @var MiddlewareInterface[] $middleware The list of middlewares to
+     * @param MiddlewareInterface[] $middleware The list of middlewares to
      * execute
      */
     public function __construct(RequestHandlerInterface $fallback, array $middleware)
@@ -40,6 +40,7 @@ class MiddlewareDispatcher implements RequestHandlerInterface
             return $this->fallback->handle($request);
         }
         $middleware = array_shift($this->middleware);
+        assert($middleware !== null);
         return $middleware->process($request, $this);
     }
 }

--- a/src/Traits/EndpointTestCases.php
+++ b/src/Traits/EndpointTestCases.php
@@ -23,7 +23,6 @@ trait EndpointTestCases
 
     /**
      * Get the endpoint under test
-     * @return Interfaces\EndpointInterface
      */
     abstract protected function getEndpoint(): EndpointInterface;
 
@@ -46,24 +45,24 @@ trait EndpointTestCases
      * and can additionally help when writing tests to assert that input
      * validation is defined correctly.
      *
-     * @param array $parsedInput The parsed request input (e.g. $_POST + $_GET,
-     *                           or json_decode(php://input)
-     * @return Containers\SafeInput
+     * @param array<string, mixed> $parsedInput The parsed request input (e.g.
+     *                                          $_POST + $_GET, or json_decode(php://input)
      */
-    protected function getSafeInput(array $parsedRequest): Containers\SafeInput
+    protected function getSafeInput(array $parsedInput): Containers\SafeInput
     {
-        return (new Containers\ParsedInput($parsedRequest))
+        return (new Containers\ParsedInput($parsedInput))
             ->validate($this->getEndpoint());
     }
+
     /**
      * @covers ::getUri
      * @dataProvider uris
      *
      * @param string $uri The URI to match against
      * @param bool $match Whether or not the provied URI should match
-     * @param array $expectedMatches Named captures in a positive match
+     * @param array<string, string> $expectedMatches Named captures in a positive match
      */
-    public function testGetUri(string $uri, bool $match, array $expectedMatches)
+    public function testGetUri(string $uri, bool $match, array $expectedMatches): void
     {
         $endpoint = $this->getEndpoint();
         $this->assertIsString(
@@ -80,6 +79,7 @@ trait EndpointTestCases
         }
     }
 
+    /** @return mixed[] */
     public function uris(): array
     {
         $good = $this->goodUris();
@@ -114,7 +114,7 @@ TEXT;
     }
 
     /** @covers ::getMethod */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $method = $this->getEndpoint()->getMethod();
         $this->assertInstanceOf(

--- a/src/Traits/EndpointTestCases.php
+++ b/src/Traits/EndpointTestCases.php
@@ -103,11 +103,17 @@ TEXT;
         );
     }
 
+    /**
+     * @return array<string, array<string, string>>
+     */
     protected function goodUris(): array
     {
         return [];
     }
 
+    /**
+     * @return string[]
+     */
     protected function badUris(): array
     {
         return [];

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -9,11 +9,12 @@ use Throwable;
 
 trait HandlesOwnErrorsTestCases
 {
+    /** @var bool */
     private $handleExceptionMayRethrow = false;
 
     abstract protected function getEndpoint(): HandlesOwnErrorsInterface;
 
-    public function setAllowHandleExceptionToRethrow(bool $allowed)
+    public function setAllowHandleExceptionToRethrow(bool $allowed): void
     {
         $this->handleExceptionMayRethrow = $allowed;
     }
@@ -22,7 +23,7 @@ trait HandlesOwnErrorsTestCases
      * @covers ::handleException
      * @dataProvider exceptionsToHandle
      */
-    public function testHandleException(Throwable $e)
+    public function testHandleException(Throwable $e): void
     {
         try {
             $response = $this->getEndpoint()->handleException($e);
@@ -57,7 +58,7 @@ trait HandlesOwnErrorsTestCases
      *  }
      *  ```
      *
-     *  @return array<array<Exception>>
+     *  @return Throwable[][]
      */
     public function exceptionsToHandle(): array
     {

--- a/src/Traits/Input/NoOptional.php
+++ b/src/Traits/Input/NoOptional.php
@@ -6,6 +6,9 @@ namespace Firehed\API\Traits\Input;
 trait NoOptional
 {
 
+    /**
+     * @return array<string, \Firehed\Input\Objects\InputObject>
+     */
     public function getOptionalInputs(): array
     {
         return [];

--- a/src/Traits/Input/NoRequired.php
+++ b/src/Traits/Input/NoRequired.php
@@ -6,6 +6,7 @@ namespace Firehed\API\Traits\Input;
 trait NoRequired
 {
 
+    /** @return array<string, \Firehed\Input\Objects\InputObject> */
     public function getRequiredInputs(): array
     {
         return [];

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -24,6 +24,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::__construct
      * @dataProvider constructProvider
+     * @param string[] $params
+     * @param class-string<\Throwable> $exceptionClass
      */
     public function testConstruct(array $params, string $exceptionClass = null): void
     {
@@ -67,6 +69,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::load
      * @dataProvider loadProvider
+     * @param class-string<\Throwable> $exceptionClass
      */
     public function testLoad(string $file, string $exceptionClass = null): void
     {
@@ -78,6 +81,9 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(ContainerInterface::class, $config);
     }
 
+    /**
+     * @return array<array<string|class-string<Throwable>>>
+     */
     public function constructProvider(): array
     {
         return [

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -25,7 +25,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
      * @covers ::__construct
      * @dataProvider constructProvider
      */
-    public function testConstruct(array $params, string $exceptionClass = null)
+    public function testConstruct(array $params, string $exceptionClass = null): void
     {
         if ($exceptionClass !== null) {
             $this->expectException($exceptionClass);
@@ -36,7 +36,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::get */
-    public function testGetInvalidKeyImplementsPsr11Behavior()
+    public function testGetInvalidKeyImplementsPsr11Behavior(): void
     {
         $config = new Config(self::VALID_BASIC_CONFIG);
         $this->expectException(NotFoundExceptionInterface::class);
@@ -44,21 +44,21 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::get */
-    public function testGetReturnsValidData()
+    public function testGetReturnsValidData(): void
     {
         $config = new Config(self::VALID_BASIC_CONFIG);
         $this->assertSame('src', $config->get(Config::KEY_SOURCE));
     }
 
     /** @covers ::has */
-    public function testHasWorksForSetKey()
+    public function testHasWorksForSetKey(): void
     {
         $config = new Config(self::VALID_BASIC_CONFIG);
         $this->assertTrue($config->has(Config::KEY_SOURCE));
     }
 
     /** @covers ::has */
-    public function testHasWorksForUnsetKey()
+    public function testHasWorksForUnsetKey(): void
     {
         $config = new Config(self::VALID_BASIC_CONFIG);
         $this->assertFalse($config->has('this_key_is_not_set'));
@@ -68,7 +68,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
      * @covers ::load
      * @dataProvider loadProvider
      */
-    public function testLoad(string $file, string $exceptionClass = null)
+    public function testLoad(string $file, string $exceptionClass = null): void
     {
         if ($exceptionClass !== null) {
             $this->expectException($exceptionClass);
@@ -120,6 +120,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /** @return string[][] */
     public function loadProvider(): array
     {
         return [

--- a/tests/Console/CompileAllTest.php
+++ b/tests/Console/CompileAllTest.php
@@ -18,7 +18,7 @@ class CompileAllTest extends \PHPUnit\Framework\TestCase
 {
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             'namespace' => 'Firehed\API',

--- a/tests/Console/CompileAllTest.php
+++ b/tests/Console/CompileAllTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CompileAllTest extends \PHPUnit\Framework\TestCase
 {
+    /** @var Config */
     private $config;
 
     public function setUp(): void
@@ -28,14 +29,14 @@ class CompileAllTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::__construct */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $config = $this->createMock(Config::class);
         $this->assertInstanceOf(Command::class, new CompileAll($this->config));
     }
 
     /** @covers ::execute */
-    public function testExecute()
+    public function testExecute(): void
     {
         try {
             $command = new CompileAll($this->config);
@@ -53,17 +54,21 @@ class CompileAllTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    private function validateEndpointList($data)
+    /**
+     * @param string[] $data
+     */
+    private function validateEndpointList(array $data): void
     {
-        $this->assertIsArray($data);
         $this->assertArrayHasKey('@gener'.'ated', $data);
         $this->assertArrayHasKey('GET', $data);
         $this->assertContains(EndpointFixture::class, $data['GET']);
     }
 
-    private function validateParserList($data)
+    /**
+     * @param string[] $data
+     */
+    private function validateParserList(array $data): void
     {
-        $this->assertIsArray($data);
         $this->assertArrayHasKey('@gener'.'ated', $data);
         $this->assertArrayHasKey('application/json', $data);
         $this->assertArrayHasKey('application/x-www-form-urlencoded', $data);

--- a/tests/Console/GenerateConfigTest.php
+++ b/tests/Console/GenerateConfigTest.php
@@ -17,7 +17,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
 {
     private $existingConfig;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (file_exists(Config::FILENAME)) {
             $this->existingConfig = tempnam(sys_get_temp_dir(), 'phpunit_apiconfig_');
@@ -25,7 +25,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unlink(Config::FILENAME);
         if ($this->existingConfig !== null) {

--- a/tests/Console/GenerateConfigTest.php
+++ b/tests/Console/GenerateConfigTest.php
@@ -21,7 +21,9 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
     public function setUp(): void
     {
         if (file_exists(Config::FILENAME)) {
-            $this->existingConfig = tempnam(sys_get_temp_dir(), 'phpunit_apiconfig_');
+            $old = tempnam(sys_get_temp_dir(), 'phpunit_apiconfig_');
+            assert($old !== false);
+            $this->existingConfig = $old;
             rename(Config::FILENAME, $this->existingConfig);
         }
     }
@@ -50,6 +52,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
         $tester->execute([]);
         $this->assertTrue(file_exists(Config::FILENAME), 'Config not written');
         $json = file_get_contents(Config::FILENAME);
+        assert($json !== false);
         $data = json_decode($json, true);
         // These are the defaults inferred from Composer and the directory
         // structure
@@ -81,6 +84,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
         $tester->setInputs(['y', 'publicdir', 'sourcedir', 'Some\\Namespace', "config.php"]);
         $tester->execute([]);
         $json = file_get_contents(Config::FILENAME);
+        assert($json !== false);
         $data = json_decode($json, true);
         $this->assertSame($data[Config::KEY_NAMESPACE], 'Some\\Namespace', 'Namespace wrong');
         $this->assertSame($data[Config::KEY_SOURCE], 'sourcedir', 'Source wrong');

--- a/tests/Console/GenerateConfigTest.php
+++ b/tests/Console/GenerateConfigTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class GenerateConfigTest extends \PHPUnit\Framework\TestCase
 {
+    /** @var string */
     private $existingConfig;
 
     public function setUp(): void
@@ -34,7 +35,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::execute */
-    public function testExecute()
+    public function testExecute(): void
     {
         // Sanity check that setUp moved any existing local file
         $this->assertFalse(file_exists(Config::FILENAME), 'Config already exists');
@@ -59,7 +60,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::execute */
-    public function testOverwriteProtection()
+    public function testOverwriteProtection(): void
     {
         $this->assertFalse(file_exists(Config::FILENAME), 'Config already exists');
         touch(Config::FILENAME);
@@ -71,7 +72,7 @@ class GenerateConfigTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::execute */
-    public function testOverwriteHappens()
+    public function testOverwriteHappens(): void
     {
         $this->assertFalse(file_exists(Config::FILENAME), 'Config already exists');
         touch(Config::FILENAME);

--- a/tests/Console/GenerateEndpointTest.php
+++ b/tests/Console/GenerateEndpointTest.php
@@ -51,6 +51,7 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
         ]);
         $this->assertTrue(file_exists('src/TestGen/Foo/Bar.php'));
         $output = file_get_contents('src/TestGen/Foo/Bar.php');
+        assert($output !== false);
 
         $lines = explode("\n", $output);
 
@@ -105,7 +106,9 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
         if (!is_dir($dir)) {
             return unlink($dir);
         }
-        foreach (scandir($dir) as $content) {
+        $contents = scandir($dir);
+        assert($contents !== false);
+        foreach ($contents as $content) {
             if ($content === '.' || $content === '..') {
                 continue;
             }

--- a/tests/Console/GenerateEndpointTest.php
+++ b/tests/Console/GenerateEndpointTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
 {
+    /** @var Config */
     private $config;
 
     public function setUp(): void
@@ -34,13 +35,13 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::__construct */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $config = $this->createMock(Config::class);
         $this->assertInstanceOf(Command::class, new GenerateEndpoint($this->config));
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $command = new GenerateEndpoint($this->config);
         $tester = new CommandTester($command);
@@ -64,7 +65,7 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testExecuteWithExistingFile()
+    public function testExecuteWithExistingFile(): void
     {
         $command = new GenerateEndpoint($this->config);
         $tester = new CommandTester($command);
@@ -80,7 +81,7 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testExecuteWithoutCreatingDirectory()
+    public function testExecuteWithoutCreatingDirectory(): void
     {
         $command = new GenerateEndpoint($this->config);
         $tester = new CommandTester($command);

--- a/tests/Console/GenerateEndpointTest.php
+++ b/tests/Console/GenerateEndpointTest.php
@@ -17,7 +17,7 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
 {
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = new Config([
             Config::KEY_NAMESPACE => 'Firehed\API\TestGen',
@@ -26,7 +26,7 @@ class GenerateEndpointTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists('src/TestGen')) {
             $this->rm('src/TestGen');

--- a/tests/Console/GenerateFrontControllerTest.php
+++ b/tests/Console/GenerateFrontControllerTest.php
@@ -16,7 +16,7 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
 {
     private $oldFrontController;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (file_exists('public/index.php')) {
             $this->oldFrontController = tempnam(sys_get_temp_dir(), 'phpunit_fc_');
@@ -24,7 +24,7 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists('public/index.php')) {
             unlink('public/index.php');

--- a/tests/Console/GenerateFrontControllerTest.php
+++ b/tests/Console/GenerateFrontControllerTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
 {
+    /** @var string */
     private $oldFrontController;
 
     public function setUp(): void
@@ -35,14 +36,14 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::__construct */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         /** @var Config */
         $config = $this->createMock(Config::class);
         $this->assertInstanceOf(Command::class, new GenerateFrontController($config));
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $config = new Config([
             Config::KEY_NAMESPACE => 'Firehed\API',
@@ -57,7 +58,7 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('<?php', $lines[0], 'Output didn\'t start with a PHP tag');
     }
 
-    public function testExecuteWithContainer()
+    public function testExecuteWithContainer(): void
     {
         $config = new Config([
             Config::KEY_CONTAINER => __DIR__ . '/config.php',

--- a/tests/Console/GenerateFrontControllerTest.php
+++ b/tests/Console/GenerateFrontControllerTest.php
@@ -20,7 +20,9 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
     public function setUp(): void
     {
         if (file_exists('public/index.php')) {
-            $this->oldFrontController = tempnam(sys_get_temp_dir(), 'phpunit_fc_');
+            $old = tempnam(sys_get_temp_dir(), 'phpunit_fc_');
+            assert($old !== false);
+            $this->oldFrontController = $old;
             rename('public/index.php', $this->oldFrontController);
         }
     }
@@ -54,6 +56,7 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
         $file = file_get_contents('public/index.php');
+        assert($file !== false);
         $lines = explode("\n", $file);
         $this->assertSame('<?php', $lines[0], 'Output didn\'t start with a PHP tag');
     }
@@ -70,6 +73,7 @@ class GenerateFrontControllerTest extends \PHPUnit\Framework\TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
         $file = file_get_contents('public/index.php');
+        assert($file !== false);
         $lines = explode("\n", $file);
         $this->assertSame('<?php', $lines[0], 'Output didn\'t start with a PHP tag');
 

--- a/tests/Console/config.php
+++ b/tests/Console/config.php
@@ -11,5 +11,6 @@ return new class implements ContainerInterface
 
     public function has($id)
     {
+        return false;
     }
 };

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -21,26 +21,26 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::__construct */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(Psr\ContainerInterface::class, $this->c);
     }
 
     /** @covers ::has */
-    public function testHas()
+    public function testHas(): void
     {
         $this->assertTrue($this->c->has('key'));
         $this->assertFalse($this->c->has('nokey'));
     }
 
     /** @covers ::get */
-    public function testGet()
+    public function testGet(): void
     {
         $this->assertSame('value', $this->c->get('key'));
     }
 
     /** @covers ::get */
-    public function testGetDoesNotEvaluateCallables()
+    public function testGetDoesNotEvaluateCallables(): void
     {
         $loader = function () {
             return new Container([]);
@@ -51,7 +51,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::get */
-    public function testGetThrowsOnMissingKey()
+    public function testGetThrowsOnMissingKey(): void
     {
         $this->expectException(Psr\NotFoundExceptionInterface::class);
         $this->c->get('nokey');

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -15,7 +15,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
     /** @var Container */
     private $c;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->c = new Container(['key' => 'value']);
     }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -36,13 +36,13 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
     private $reporting;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->reporting = error_reporting();
         error_reporting($this->reporting & ~E_USER_DEPRECATED);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         error_reporting($this->reporting);
     }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -288,13 +288,13 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers ::dispatch
-     * @expectedException OutOfBoundsException
-     * @expectedExceptionCode 404
      */
     public function testNoRouteMatchReturns404()
     {
         $req = $this->getMockRequestWithUriPath('/');
 
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionCode(404);
         $ret = (new Dispatcher())
             ->setEndpointList([]) // No routes
             ->setParserList([])

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -115,7 +115,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         $this->checkResponse($response, 200);
-        $data = json_decode($response->getBody(), true);
+        $data = json_decode((string)$response->getBody(), true);
         $this->assertSame(
             [
                 'id' => 5,
@@ -146,7 +146,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         $this->checkResponse($response, 200);
-        $data = json_decode($response->getBody(), true);
+        $data = json_decode((string)$response->getBody(), true);
         $this->assertSame(
             [
                 'id' => 5,

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -34,6 +34,7 @@ use Zend\Diactoros\Stream;
 class DispatcherTest extends \PHPUnit\Framework\TestCase
 {
 
+    /** @var int */
     private $reporting;
 
     public function setUp(): void
@@ -47,7 +48,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         error_reporting($this->reporting);
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(
             Dispatcher::class,
@@ -58,7 +59,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     // ----(Setters)-----------------------------------------------------------
 
     /** @covers ::setContainer */
-    public function testSetContainerReturnsSelf()
+    public function testSetContainerReturnsSelf(): void
     {
         $d = new Dispatcher();
         $container = $this->getMockContainer([]);
@@ -70,7 +71,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::setEndpointList */
-    public function testSetEndpointListReturnsSelf()
+    public function testSetEndpointListReturnsSelf(): void
     {
         $d = new Dispatcher();
         $this->assertSame(
@@ -81,7 +82,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::setParserList */
-    public function testSetParserListReturnsSelf()
+    public function testSetParserListReturnsSelf(): void
     {
         $d = new Dispatcher();
         $this->assertSame(
@@ -99,7 +100,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::dispatch
      */
-    public function testDataReachesEndpoint()
+    public function testDataReachesEndpoint(): void
     {
         // See tests/EndpointFixture
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
@@ -131,7 +132,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::dispatch
      */
-    public function testQueryStringDataReachesEndpoint()
+    public function testQueryStringDataReachesEndpoint(): void
     {
         // See tests/EndpointFixture
         $req = $this->getMockRequestWithUriPath(
@@ -165,7 +166,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::dispatch
      */
-    public function testContainerClassIsPrioritized()
+    public function testContainerClassIsPrioritized(): void
     {
         $endpoint = $this->getMockEndpoint();
         $endpoint->expects($this->atLeastOnce())
@@ -182,7 +183,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::handle
      */
-    public function testPsr15()
+    public function testPsr15(): void
     {
         $request = $this->createMock(ServerRequestInterface::class);
         $modifiedRequest = $this->getMockRequestWithUriPath('/c', 'GET', []);
@@ -235,7 +236,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::dispatch
      */
-    public function testWhenEndpointsOwnErrorHandlerThrows()
+    public function testWhenEndpointsOwnErrorHandlerThrows(): void
     {
         $execute = new Exception('Execute error');
         $error = new Exception('Exception handler error');
@@ -279,7 +280,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::dispatch
      */
-    public function testDispatchThrowsWhenMissingData()
+    public function testDispatchThrowsWhenMissingData(): void
     {
         $d = new Dispatcher();
         $this->expectException(InvalidArgumentException::class);
@@ -289,7 +290,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::dispatch
      */
-    public function testNoRouteMatchReturns404()
+    public function testNoRouteMatchReturns404(): void
     {
         $req = $this->getMockRequestWithUriPath('/');
 
@@ -302,7 +303,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::dispatch */
-    public function testFailedInputValidationCanReachErrorHandlers()
+    public function testFailedInputValidationCanReachErrorHandlers(): void
     {
         // See tests/EndpointFixture
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
@@ -324,7 +325,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::dispatch */
-    public function testUnsupportedContentTypeCanReachErrorHandlers()
+    public function testUnsupportedContentTypeCanReachErrorHandlers(): void
     {
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
         /** @var ServerRequestInterface */
@@ -344,7 +345,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::dispatch
      */
-    public function testMatchingContentTypeWithDirectives()
+    public function testMatchingContentTypeWithDirectives(): void
     {
         $contentType = 'application/json; charset=utf-8';
         $req = $this->getMockRequestWithUriPath('/user/5', 'POST');
@@ -358,7 +359,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::dispatch */
-    public function testFailedEndpointExecutionReachesEndpointErrorHandler()
+    public function testFailedEndpointExecutionReachesEndpointErrorHandler(): void
     {
         $e = new Exception('This should reach the error handler');
         $endpoint = $this->getMockEndpoint(HandlesOwnErrorsInterface::class);
@@ -372,7 +373,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
 
     /** @covers ::dispatch */
-    public function testScalarResponseFromEndpointReachesErrorHandler()
+    public function testScalarResponseFromEndpointReachesErrorHandler(): void
     {
         $endpoint = $this->getMockEndpoint(HandlesOwnErrorsInterface::class);
         $endpoint->expects($this->atLeastOnce())
@@ -384,7 +385,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::dispatch */
-    public function testInvalidTypeResponseFromEndpointReachesErrorHandler()
+    public function testInvalidTypeResponseFromEndpointReachesErrorHandler(): void
     {
         $endpoint = $this->getMockEndpoint(HandlesOwnErrorsInterface::class);
         $endpoint->expects($this->atLeastOnce())
@@ -399,7 +400,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
      */
-    public function testErrorHandlerHandlesExceptionFromEndpointExecute()
+    public function testErrorHandlerHandlesExceptionFromEndpointExecute(): void
     {
         $ex = new Exception('execute');
         $handler = $this->createMock(HandlerInterface::class);
@@ -424,7 +425,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
      */
-    public function testErrorHandlerHandles404()
+    public function testErrorHandlerHandles404(): void
     {
         $response = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(HandlerInterface::class);
@@ -452,7 +453,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
      */
-    public function testExceptionsFromEndpointsOwnHandlerReachDefaultHandlerWhenSet()
+    public function testExceptionsFromEndpointsOwnHandlerReachDefaultHandlerWhenSet(): void
     {
         $first = new Exception('This is the initially thrown exception');
         $second = new Exception('This should reach the main error handler');
@@ -483,7 +484,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::dispatch */
-    public function testExceptionsLeakWhenNoErrorHandler()
+    public function testExceptionsLeakWhenNoErrorHandler(): void
     {
         $e = new Exception('This should reach the top level');
 
@@ -503,7 +504,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
     */
-    public function testAuthHappensWhenProvided()
+    public function testAuthHappensWhenProvided(): void
     {
         $authContainer = $this->createMock(ContainerInterface::class);
 
@@ -542,7 +543,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
      */
-    public function testExecuteIsNotCalledWhenAuthzFails()
+    public function testExecuteIsNotCalledWhenAuthzFails(): void
     {
         $authContainer = $this->createMock(ContainerInterface::class);
         $authn = $this->createMock(Authentication\ProviderInterface::class);
@@ -578,7 +579,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::dispatch
      * @covers ::setContainer
      */
-    public function testExecuteIsNotCalledWhenAuthnFails()
+    public function testExecuteIsNotCalledWhenAuthnFails(): void
     {
         $authnEx = new Authentication\Exception();
         $authn = $this->createMock(Authentication\ProviderInterface::class);
@@ -610,7 +611,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @covers ::addMiddleware
      * @covers ::dispatch
      */
-    public function testDispatchRunsMiddlewareOnSubsequentRequests()
+    public function testDispatchRunsMiddlewareOnSubsequentRequests(): void
     {
         $called = 0;
         $mw = $this->createMock(MiddlewareInterface::class);
@@ -729,6 +730,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         return $response;
     }
 
+    /** @return string[][] */
     private function getEndpointListForFixture(): array
     {
         return [
@@ -747,6 +749,9 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         return dirname(__DIR__).'/vendor/firehed/input/src/Parsers/__parser_list__.json';
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     private function getMockContainer(array $values): ContainerInterface
     {
         $container = $this->createMock(ContainerInterface::class);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -613,25 +613,17 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      */
     public function testDispatchRunsMiddlewareOnSubsequentRequests(): void
     {
-        $called = 0;
-        $mw = $this->createMock(MiddlewareInterface::class);
-        $mw->expects($this->exactly(2))
-            ->method('process')
-            ->willReturnCallback(function ($req, $handler) use (&$called) {
-                $called++;
-                return $handler->handle($req);
-            });
-
+        $mw = new fixtures\Middleware();
         $ep = $this->getMockEndpoint();
 
         $dispatcher = new Dispatcher();
         $dispatcher->addMiddleware($mw);
 
-        $this->assertSame(0, $called, 'MW should not be called yet');
+        $this->assertSame(0, $mw->getProcessedCount(), 'MW should not be called yet');
         $this->executeMockRequestOnEndpoint($ep, [], $dispatcher);
-        $this->assertSame(1, $called, 'MW should be called once');
+        $this->assertSame(1, $mw->getProcessedCount(), 'MW should be called once');
         $this->executeMockRequestOnEndpoint($ep, [], $dispatcher);
-        $this->assertSame(2, $called, 'MW should be called twice');
+        $this->assertSame(2, $mw->getProcessedCount(), 'MW should be called twice');
     }
 
     // ----(Helper methods)----------------------------------------------------
@@ -640,7 +632,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * @param ResponseInterface $response response to test
      * @param int $expected_code HTTP status code to check for
      */
-    private function checkResponse(ResponseInterface $response, int $expected_code)
+    private function checkResponse(ResponseInterface $response, int $expected_code): void
     {
         $this->assertSame(
             $expected_code,
@@ -656,7 +648,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      *
      * @param string $uri path component of URI
      * @param string $method optional HTTP method
-     * @param array $query_data optional raw, unescaped query string data
+     * @param mixed[] $query_data optional raw, unescaped query string data
      * @return ServerRequestInterface
      */
     private function getMockRequestWithUriPath(
@@ -700,7 +692,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
      * Run the endpoint with an empty request
      *
      * @param EndpointInterface $endpoint the endpoint to test
-     * @param array $containerValues Additional container values
+     * @param mixed[] $containerValues Additional container values
      * @param ?Dispatcher $dispatcher a configured dispatcher
      * @return ResponseInterface the endpoint response
      */

--- a/tests/EndpointFixture.php
+++ b/tests/EndpointFixture.php
@@ -8,7 +8,7 @@ use Throwable;
 use Firehed\Input\Containers\SafeInput;
 use Firehed\Input\Objects\InputObject;
 use PHPUnit\Framework\MockObject\Generator;
-use PHPUnit\Framework\MockObject\Matcher\InvokedAtLeastOnce;
+use PHPUnit\Framework\MockObject\Rule\InvokedAtLeastOnce;
 use PHPUnit\Framework\MockObject\Stub\ReturnStub;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;

--- a/tests/EndpointFixture.php
+++ b/tests/EndpointFixture.php
@@ -27,6 +27,7 @@ class EndpointFixture implements Interfaces\EndpointInterface
     {
         return [
             'id' => new class extends InputObject {
+                /** @param mixed $value */
                 public function validate($value): bool
                 {
                     return ((int)$value) == $value;
@@ -44,6 +45,7 @@ class EndpointFixture implements Interfaces\EndpointInterface
     {
         return [
             'shortstring' => new class extends InputObject {
+                /** @param mixed $value */
                 public function validate($value): bool
                 {
                     return strlen($value) <= 5;

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -17,7 +17,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::__construct
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertInstanceOf(
             ErrorHandler::class,
@@ -29,7 +29,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
      * @covers ::handleThrowable
      * @runInSeparateProcess
      */
-    public function testHandleThrowable()
+    public function testHandleThrowable(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->atLeastOnce())
@@ -42,7 +42,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::handleError
      */
-    public function testHandleError()
+    public function testHandleError(): void
     {
         $handler = new ErrorHandler($this->createMock(LoggerInterface::class));
         $this->expectException(ErrorException::class);
@@ -53,7 +53,7 @@ class ErrorHandlerTest extends \PHPUnit\Framework\TestCase
      * @covers ::handleError
      * @doesNotPerformAssertions
      */
-    public function testHandleErrorDoesNotThrowWithErrorReportingDisabled()
+    public function testHandleErrorDoesNotThrowWithErrorReportingDisabled(): void
     {
         $handler = new ErrorHandler($this->createMock(LoggerInterface::class));
         // @ turns error_reporting() to 0 for the next line. The error handler

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -16,7 +16,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 class MiddlewareDispatcherTest extends \PHPUnit\Framework\TestCase
 {
     /** @covers ::__construct */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $fallback = $this->createMock(RequestHandlerInterface::class);
         $mw = $this->createMock(MiddlewareInterface::class);
@@ -26,7 +26,7 @@ class MiddlewareDispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::handle */
-    public function testMiddlewareIsExecutedInOrder()
+    public function testMiddlewareIsExecutedInOrder(): void
     {
         // This is an object cast to ensure proper by-reference handling in all
         // of the mock callbacks
@@ -82,7 +82,7 @@ class MiddlewareDispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::handle */
-    public function testMiddlewareCanShortCircuit()
+    public function testMiddlewareCanShortCircuit(): void
     {
         $fallback = $this->createMock(RequestHandlerInterface::class);
         $fallback->expects($this->never())
@@ -103,7 +103,7 @@ class MiddlewareDispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @covers ::handle */
-    public function testWithNoMiddleware()
+    public function testWithNoMiddleware(): void
     {
         $fallback = $this->createMock(RequestHandlerInterface::class);
         $fallback->expects($this->once())

--- a/tests/ResponseRendererTest.php
+++ b/tests/ResponseRendererTest.php
@@ -21,7 +21,7 @@ class ResponseRendererTest extends \PHPUnit\Framework\TestCase
      * @covers ::sendBody
      * @runInSeparateProcess
      */
-    public function testResponseRendering()
+    public function testResponseRendering(): void
     {
         $code = 999;
         $version = 1.2;

--- a/tests/Traits/EndpointTestCasesTest.php
+++ b/tests/Traits/EndpointTestCasesTest.php
@@ -33,7 +33,7 @@ class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Firehed\API\Traits\EndpointTestCases::getSafeInput
      */
-    public function testGetSafeInput()
+    public function testGetSafeInput(): void
     {
         $data = $this->getSafeInput([
             'id' => '123',
@@ -47,7 +47,7 @@ class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Firehed\API\Traits\EndpointTestCases::uris
      */
-    public function testUris()
+    public function testUris(): void
     {
         $data = $this->uris();
         foreach ($data as $testCase) {
@@ -58,6 +58,7 @@ class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /** @return array<string, string[]> */
     public function goodUris(): array
     {
         return $this->baseGoodUris() + [
@@ -68,6 +69,7 @@ class EndpointTestCasesTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /** @return string[] */
     public function badUris(): array
     {
         return $this->baseBadUris() + [

--- a/tests/Traits/HandlesOwnErrorsTestCasesTest.php
+++ b/tests/Traits/HandlesOwnErrorsTestCasesTest.php
@@ -16,6 +16,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
 {
     use HandlesOwnErrorsTestCases;
 
+    /** @var bool */
     private $endpointShouldThrow = true;
 
     public function setUp(): void
@@ -41,7 +42,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::exceptionsToHandle
      */
-    public function testExceptionsToHandle()
+    public function testExceptionsToHandle(): void
     {
         $data = $this->exceptionsToHandle();
         foreach ($data as $testCase) {
@@ -55,7 +56,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
      * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
      * @dataProvider exceptionsToHandle
      */
-    public function testDefaultHandling(Throwable $e)
+    public function testDefaultHandling(Throwable $e): void
     {
         $this->setAllowHandleExceptionToRethrow(false);
         $this->expectException(get_class($e));
@@ -65,7 +66,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
      */
-    public function testSuccessfullyHandlingException()
+    public function testSuccessfullyHandlingException(): void
     {
         $this->endpointShouldThrow = false;
         $ex = new \Exception();
@@ -75,7 +76,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Firehed\API\Traits\HandlesOwnErrorsTestCases::testHandleException
      */
-    public function testHandlingRethrownException()
+    public function testHandlingRethrownException(): void
     {
         $this->endpointShouldThrow = true;
         $this->setAllowHandleExceptionToRethrow(true);

--- a/tests/Traits/HandlesOwnErrorsTestCasesTest.php
+++ b/tests/Traits/HandlesOwnErrorsTestCasesTest.php
@@ -18,7 +18,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
 
     private $endpointShouldThrow = true;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setAllowHandleExceptionToRethrow(true);
         $this->endpointShouldThrow = true;

--- a/tests/Traits/Input/NoOptionalTest.php
+++ b/tests/Traits/Input/NoOptionalTest.php
@@ -14,7 +14,7 @@ class NoOptionalTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getOptionalInputs
      */
-    public function testGetOptionalInputs()
+    public function testGetOptionalInputs(): void
     {
         $obj = new class {
             use NoOptional;

--- a/tests/Traits/Input/NoRequiredTest.php
+++ b/tests/Traits/Input/NoRequiredTest.php
@@ -14,7 +14,7 @@ class NoRequiredTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getRequiredInputs
      */
-    public function testGetRequiredInputs()
+    public function testGetRequiredInputs(): void
     {
         $obj = new class {
             use NoRequired;

--- a/tests/Traits/Request/DeleteTest.php
+++ b/tests/Traits/Request/DeleteTest.php
@@ -14,7 +14,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Delete;

--- a/tests/Traits/Request/GetTest.php
+++ b/tests/Traits/Request/GetTest.php
@@ -14,7 +14,7 @@ class GetTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Get;

--- a/tests/Traits/Request/OptionsTest.php
+++ b/tests/Traits/Request/OptionsTest.php
@@ -14,7 +14,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Options;

--- a/tests/Traits/Request/PatchTest.php
+++ b/tests/Traits/Request/PatchTest.php
@@ -14,7 +14,7 @@ class PatchTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Patch;

--- a/tests/Traits/Request/PostTest.php
+++ b/tests/Traits/Request/PostTest.php
@@ -15,7 +15,7 @@ class PostTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Post;

--- a/tests/Traits/Request/PutTest.php
+++ b/tests/Traits/Request/PutTest.php
@@ -14,7 +14,7 @@ class PutTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getMethod
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $obj = new class {
             use Put;

--- a/tests/Traits/ResponseBuilderTest.php
+++ b/tests/Traits/ResponseBuilderTest.php
@@ -16,7 +16,7 @@ class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::emptyResponse
      */
-    public function testEmptyResponse()
+    public function testEmptyResponse(): void
     {
         $impl = new class { use ResponseBuilder;
 
@@ -44,7 +44,7 @@ class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::htmlResponse
      */
-    public function testHtmlResponse()
+    public function testHtmlResponse(): void
     {
         $impl = new class { use ResponseBuilder;
 
@@ -75,8 +75,9 @@ class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::jsonResponse
      * @dataProvider jsonData
+     * @param mixed $data
      */
-    public function testJsonResponse($data)
+    public function testJsonResponse($data): void
     {
         $impl = new class { use ResponseBuilder;
 
@@ -106,7 +107,7 @@ class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::textResponse
      */
-    public function testtextResponse()
+    public function testTextResponse(): void
     {
         $impl = new class { use ResponseBuilder;
 
@@ -134,7 +135,7 @@ class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-
+    /** @return mixed[][] */
     public function jsonData(): array
     {
         return [

--- a/tests/fixtures/Endpoint.php
+++ b/tests/fixtures/Endpoint.php
@@ -22,6 +22,7 @@ class Endpoint implements EndpointInterface
 
     public function handleException(Throwable $e): ResponseInterface
     {
+        throw $e;
     }
 
     public function getUri(): string

--- a/tests/fixtures/Middleware.php
+++ b/tests/fixtures/Middleware.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\API\fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class Middleware implements MiddlewareInterface
+{
+    /** @var int */
+    private $processed = 0;
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $this->processed++;
+        return $handler->handle($request);
+    }
+
+    public function getProcessedCount(): int
+    {
+        return $this->processed;
+    }
+}


### PR DESCRIPTION
For the most part, this just adds type information where it was missing and couldn't be inferred. There are a couple of small changes to work around shortcomings, and a couple issues that we just have to live with for now.