### PR TITLE
Fix types on ErrorHandler

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -29,15 +29,14 @@ class ErrorHandler
     }
 
     /**
-     * @param int $severity
-     * @param string $message
      * @param string $file
      * @param int $line
      */
-    public function handleError($severity, $message, $file, $line): void
+    public function handleError(int $severity, string $message, $file, $line): bool
     {
         if (error_reporting() & $severity) {
             throw new ErrorException($message, 0, $severity, $file, $line);
         }
+        return false;
     }
 }


### PR DESCRIPTION
It returns a bool, not void. Default to false to replicate previous behavior.