### PR TITLE
Resolve potential naming conflict under PHP8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Legacy "response" middleware support has been removed. Only PSR-15 middleware is supported.
 - `Dispatcher::setAuthProviders()` and `::setErrorHandler` have been removed. You must provide them with a container now, and they will be fetched lazily.
 - `Dispatcher::setRequest(ServerRequestInterface)` has been removed, and the request is now provided directly to `::dispatch(ServerRequestInterface)`
+- `HandlesOwnErrorsTestCases::getEndpoint()` has been renamed to `HandlesOwnErrorsTestCases::getErrorHandlingEndpoint()`.
+  This prevents an incompatibility in PHP8 from abstract trait method validation colliding with LSP enforcement.
 
 ### Added
 - `Traits\EndpointTestCases::getSafeInput()`

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -12,7 +12,7 @@ trait HandlesOwnErrorsTestCases
     /** @var bool */
     private $handleExceptionMayRethrow = false;
 
-    abstract protected function getEndpoint(): HandlesOwnErrorsInterface;
+    abstract protected function getErrorHandlngEndpoint(): HandlesOwnErrorsInterface;
 
     public function setAllowHandleExceptionToRethrow(bool $allowed): void
     {
@@ -26,7 +26,7 @@ trait HandlesOwnErrorsTestCases
     public function testHandleException(Throwable $e): void
     {
         try {
-            $response = $this->getEndpoint()->handleException($e);
+            $response = $this->getErrorHandlingEndpoint()->handleException($e);
             $this->assertInstanceOf(
                 ResponseInterface::class,
                 $response,

--- a/src/Traits/HandlesOwnErrorsTestCases.php
+++ b/src/Traits/HandlesOwnErrorsTestCases.php
@@ -12,7 +12,7 @@ trait HandlesOwnErrorsTestCases
     /** @var bool */
     private $handleExceptionMayRethrow = false;
 
-    abstract protected function getErrorHandlngEndpoint(): HandlesOwnErrorsInterface;
+    abstract protected function getErrorHandlingEndpoint(): HandlesOwnErrorsInterface;
 
     public function setAllowHandleExceptionToRethrow(bool $allowed): void
     {

--- a/tests/Traits/HandlesOwnErrorsTestCasesTest.php
+++ b/tests/Traits/HandlesOwnErrorsTestCasesTest.php
@@ -25,7 +25,7 @@ class HandlesOwnErrorsTestCasesTest extends \PHPUnit\Framework\TestCase
         $this->endpointShouldThrow = true;
     }
 
-    protected function getEndpoint(): HandlesOwnErrorsInterface
+    protected function getErrorHandlingEndpoint(): HandlesOwnErrorsInterface
     {
         $mock = $this->createMock(HandlesOwnErrorsInterface::class);
         $mock->method('handleException')


### PR DESCRIPTION
Long story short, if a test class uses both of these testing interfaces, the two abstract `getEndpoint()` methods create an unresolvable type that becomes a fatal error under PHP 8 since abstract trait method validation and stricter LSP enforcement collide. Without intersection types (which probably will not happen in time), this is effectively unfixable.

The easiest approach here is simply renaming a method, which I've validated corrects the issue under PHP 8.