### PR TITLE
Change fetch-depth during build for code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # Needed for codecov to find "real" commit
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
GITHUB_SHA is a lie and the codecov action works around it, but their workaround only works with a checkout depth > 1.