### PR TITLE
Drop use of fake-enums and remove Common library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Framework-generated files are now auto-detected thanks to the above compile requirement (#84)
 - `Dispatcher::setEndpointList()` and `Dispatcher::setParserList()` are now internal use only, and are no longer called in the generated front controller (#84)
 - `Dispatcher::dispatch()` now requires `ServerRequestInterface` as a parameter. This replaces `setRequest` (#101)
+- The body parser list (based on MIME-types) is now explicitly hardcoded.
+  Previously this was tied to a scanned vendor directory, so in practice nothing has changed.
+  This may become configurable in the future.
+- Dispatcher::ENDPOINT_LIST has been marked internal
 
 ### Deprecated
 - Direct use of the HTTPMethod class is considered deprecated.
@@ -44,6 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `Dispatcher::setAuthProviders()` (use setContainer)
 - `Dispatcher::setErrorHandler()` (use setContainer)
 - `Dispatcher::setRequest()` (provide the request directly to `::dispatch()`)
+- `Dispatcher::PARSER_LIST` constant
 - `Interfaces\EndpointInterface::authenticate()` - this drops legacy authentication support entirely, and will no longer be used even if still defined in implementing classes
 - `Traits\Authentication\BearerToken`
 - `Traits\DeleteRequest`

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,6 @@
 coverage:
   status:
-    patch:
-      default:
-        threshold: 0.5%
+    patch: false
     project:
       default:
         threshold: 0.5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    patch:
+      default:
+        threshold: 0.5%
     project:
       default:
         threshold: 0.5%

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "An API framework",
     "require": {
         "php": "^7.4 || ^8.0",
-        "firehed/common": "^1.0.5",
         "firehed/input": "^2.1.5",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "An API framework",
     "require": {
         "php": "^7.4 || ^8.0",
+        "composer/composer": "^1.0 || ^2.0",
         "firehed/input": "^2.1.5",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "An API framework",
     "require": {
         "php": "^7.4 || ^8.0",
-        "composer/composer": "^1.0 || ^2.0",
+        "composer/composer": "^2.1",
         "firehed/input": "^2.1.5",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
-			count: 1
-			path: tests/ConfigTest.php
-
-		-
 			message: "#^Method Firehed\\\\API\\\\ConfigTest\\:\\:constructProvider\\(\\) should return array\\<array\\<string\\>\\> but returns array\\<int, array\\<int, array\\<string, string\\>\\|class\\-string\\>\\>\\.$#"
 			count: 1
 			path: tests/ConfigTest.php
@@ -13,5 +8,25 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
 			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$exception of method PHPUnit\\\\Framework\\\\TestCase\\:\\:expectException\\(\\) expects class\\-string\\<Throwable\\>, string given\\.$#"
+			count: 1
 			path: tests/ContainerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$endpointList of method Firehed\\\\API\\\\Dispatcher\\:\\:setEndpointList\\(\\) expects array\\<'DELETE'\\|'GET'\\|'OPTIONS'\\|'PATCH'\\|'POST'\\|'PUT', array\\<string, class\\-string\\<Firehed\\\\API\\\\Interfaces\\\\EndpointInterface\\>\\>\\>\\|string, array\\('GET' \\=\\> array\\('/c' \\=\\> 'EP'\\)\\) given\\.$#"
+			count: 1
+			path: tests/DispatcherTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$endpointList of method Firehed\\\\API\\\\Dispatcher\\:\\:setEndpointList\\(\\) expects array\\<'DELETE'\\|'GET'\\|'OPTIONS'\\|'PATCH'\\|'POST'\\|'PUT', array\\<string, class\\-string\\<Firehed\\\\API\\\\Interfaces\\\\EndpointInterface\\>\\>\\>\\|string, array\\('GET' \\=\\> array\\('/cb' \\=\\> 'CBClass'\\)\\) given\\.$#"
+			count: 1
+			path: tests/DispatcherTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$endpointList of method Firehed\\\\API\\\\Dispatcher\\:\\:setEndpointList\\(\\) expects array\\<'DELETE'\\|'GET'\\|'OPTIONS'\\|'PATCH'\\|'POST'\\|'PUT', array\\<string, class\\-string\\<Firehed\\\\API\\\\Interfaces\\\\EndpointInterface\\>\\>\\>\\|string, array\\('GET' \\=\\> array\\('/container' \\=\\> 'ClassThatDoesNotExi…'\\)\\) given\\.$#"
+			count: 1
+			path: tests/DispatcherTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,10 +2,10 @@ includes:
     - phpstan-baseline.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
 parameters:
-    ignoreErrors:
-        - '#Call to method setInterface\(\) on an unknown class Firehed\\Common\\this#'
     excludes_analyse:
         - vendor
-    level: 8
+    level: max
+    paths:
+        - .
     stubFiles:
         - tests/stubs/xdebug_get_headers.stub

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -31,6 +31,7 @@ use function array_key_exists;
  */
 class Dispatcher implements RequestHandlerInterface
 {
+    /** @internal */
     const ENDPOINT_LIST = '__endpoint_list__.php';
 
     /** @var ?ContainerInterface */

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -169,12 +169,17 @@ class Dispatcher implements RequestHandlerInterface
         foreach ($endpointsForMethod as $uri => $fqcn) {
             $pattern = '#^' . $uri . '#';
             if (preg_match($pattern, $requestPath, $match)) {
-                // TODO: filter numeric keys
+                // Filter out numeric keys from match output - we only want to
+                // retain named captures
+                foreach ($match as $key => $_) {
+                    if (is_int($key)) {
+                        unset($match[$key]);
+                    }
+                }
                 return [$fqcn, $match];
             }
         }
-        // nope
-        // print_r($endpointsForMethod);
+        // No match
         return [null, null];
     }
 
@@ -279,8 +284,8 @@ class Dispatcher implements RequestHandlerInterface
     }
 
     /**
-     * @param string|string[] $file
-     * @return string[]
+     * @param string|string[]|string[][] $file
+     * @return string[]|string[][]
      */
     private static function loadConfigFile($file): array
     {
@@ -289,11 +294,7 @@ class Dispatcher implements RequestHandlerInterface
         } elseif (is_string($file)) {
             if (!file_exists($file)) {
                 throw new InvalidArgumentException('Invalid file');
-                // throw
             }
-            // if php include
-            // elseif json
-            // Avoid weird scope issues
             return (fn () => include $file)();
         } else {
             throw new InvalidArgumentException('Invalid format');

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -27,7 +27,7 @@ use function preg_match;
 use function array_key_exists;
 
 /**
- * @phpstan-type EndpointMap array<string, array<string, class-string<Interfaces\EndpointInterface>>>
+ * @phpstan-type EndpointMap array<Enums\HTTPMethod::*, array<string, class-string<Interfaces\EndpointInterface>>>
  */
 class Dispatcher implements RequestHandlerInterface
 {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -22,9 +22,17 @@ use Throwable;
 use OutOfBoundsException;
 use UnexpectedValueException;
 
-use function strtoupper;
-use function preg_match;
 use function array_key_exists;
+use function array_shift;
+use function assert;
+use function explode;
+use function file_exists;
+use function is_array;
+use function is_int;
+use function is_string;
+use function parse_str;
+use function preg_match;
+use function strtoupper;
 
 /**
  * @phpstan-type EndpointMap array<Enums\HTTPMethod::*, array<string, class-string<Interfaces\EndpointInterface>>>

--- a/src/Enums/HTTPMethod.php
+++ b/src/Enums/HTTPMethod.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace Firehed\API\Enums;
 
-use Firehed\Common\Enum;
-
 /**
  * Direct use of this class (via these static methods) is deprecated. Instead,
  * implementations should rely on the Request traits.
  *
  * This will be converted to a native Enum in PHP 8.1.
- *
- * @method static HTTPMethod DELETE()
- * @method static HTTPMethod GET()
- * @method static HTTPMethod OPTIONS()
- * @method static HTTPMethod PATCH()
- * @method static HTTPMethod POST()
- * @method static HTTPMethod PUT()
  */
-class HTTPMethod extends Enum
+interface HTTPMethod
 {
-
     // Other methods exist, but these are the only relevant ones for RESTful
     // APIs
     const GET = 'GET';
@@ -30,9 +20,4 @@ class HTTPMethod extends Enum
     const PUT = 'PUT';
     const DELETE = 'DELETE';
     const OPTIONS = 'OPTIONS';
-
-    public function __toString()
-    {
-        return $this->getValue();
-    }
 }

--- a/src/Interfaces/EndpointInterface.php
+++ b/src/Interfaces/EndpointInterface.php
@@ -64,7 +64,7 @@ interface EndpointInterface extends ValidationInterface
      * Indiate the HTTP request method that must be used for inbound requests
      * to be routed to this endpoint.
      *
-     * @return HTTPMethod
+     * @return HTTPMethod::*
      */
-    public function getMethod(): HTTPMethod;
+    public function getMethod(): string;
 }

--- a/src/Traits/EndpointTestCases.php
+++ b/src/Traits/EndpointTestCases.php
@@ -9,6 +9,7 @@ use Firehed\Input\Containers;
 use Firehed\Input\Interfaces\ValidationInterface;
 use Firehed\Input\SafeInputTestTrait;
 use Firehed\Input\ValidationTestTrait;
+use ReflectionClass;
 
 /**
  * Default test cases to be run against any object implementing
@@ -123,10 +124,10 @@ TEXT;
     public function testGetMethod(): void
     {
         $method = $this->getEndpoint()->getMethod();
-        $this->assertInstanceOf(
-            'Firehed\API\Enums\HTTPMethod',
-            $method,
-            'getMethod did not return an HTTPMethod enum'
-        );
+        // 8.1: Enum logic
+
+        $rc = new ReflectionClass(HTTPMethod::class);
+        $constants = $rc->getConstants();
+        $this->assertContains($constants, $method, 'Invalid HTTP method');
     }
 }

--- a/src/Traits/EndpointTestCases.php
+++ b/src/Traits/EndpointTestCases.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\API\Traits;
 
 use Firehed\API\Interfaces\EndpointInterface;
+use Firehed\API\Enums\HTTPMethod;
 use Firehed\Input\Containers;
 use Firehed\Input\Interfaces\ValidationInterface;
 use Firehed\Input\SafeInputTestTrait;
@@ -128,6 +129,6 @@ TEXT;
 
         $rc = new ReflectionClass(HTTPMethod::class);
         $constants = $rc->getConstants();
-        $this->assertContains($constants, $method, 'Invalid HTTP method');
+        $this->assertContains($method, $constants, 'Invalid HTTP method');
     }
 }

--- a/src/Traits/Request/Delete.php
+++ b/src/Traits/Request/Delete.php
@@ -7,9 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Delete
 {
-
-    public function getMethod(): HTTPMethod
+    public function getMethod(): string
     {
-        return HTTPMethod::DELETE();
+        return HTTPMethod::DELETE;
     }
 }

--- a/src/Traits/Request/Get.php
+++ b/src/Traits/Request/Get.php
@@ -7,9 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Get
 {
-
-    public function getMethod(): HTTPMethod
+    public function getMethod(): string
     {
-        return HTTPMethod::GET();
+        return HTTPMethod::GET;
     }
 }

--- a/src/Traits/Request/Options.php
+++ b/src/Traits/Request/Options.php
@@ -7,9 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Options
 {
-
-    public function getMethod(): HTTPMethod
+    public function getMethod(): string
     {
-        return HTTPMethod::OPTIONS();
+        return HTTPMethod::OPTIONS;
     }
 }

--- a/src/Traits/Request/Patch.php
+++ b/src/Traits/Request/Patch.php
@@ -7,8 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Patch
 {
-    public function getMethod(): HTTPMethod
+    public function getMethod(): string
     {
-        return HTTPMethod::PATCH();
+        return HTTPMethod::PATCH;
     }
 }

--- a/src/Traits/Request/Post.php
+++ b/src/Traits/Request/Post.php
@@ -7,9 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Post
 {
-
-    public function getMethod(): HTTPMethod
+    public function getMethod()
     {
-        return HTTPMethod::POST();
+        return HTTPMethod::POST;
     }
 }

--- a/src/Traits/Request/Post.php
+++ b/src/Traits/Request/Post.php
@@ -7,7 +7,7 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Post
 {
-    public function getMethod()
+    public function getMethod(): string
     {
         return HTTPMethod::POST;
     }

--- a/src/Traits/Request/Put.php
+++ b/src/Traits/Request/Put.php
@@ -7,8 +7,8 @@ use Firehed\API\Enums\HTTPMethod;
 
 trait Put
 {
-    public function getMethod(): HTTPMethod
+    public function getMethod(): string
     {
-        return HTTPMethod::PUT();
+        return HTTPMethod::PUT;
     }
 }

--- a/tests/Console/CompileAllTest.php
+++ b/tests/Console/CompileAllTest.php
@@ -43,14 +43,10 @@ class CompileAllTest extends \PHPUnit\Framework\TestCase
             $tester = new CommandTester($command);
             $tester->execute([]);
             $this->assertFileExists(Dispatcher::ENDPOINT_LIST, 'Endpoint list not generated');
-            $this->assertFileExists(Dispatcher::PARSER_LIST, 'Parser list not generated');
             $endpoints = include Dispatcher::ENDPOINT_LIST;
-            $parsers = include Dispatcher::PARSER_LIST;
             $this->validateEndpointList($endpoints);
-            $this->validateParserList($parsers);
         } finally {
             @unlink(Dispatcher::ENDPOINT_LIST);
-            @unlink(Dispatcher::PARSER_LIST);
         }
     }
 
@@ -62,15 +58,5 @@ class CompileAllTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('@gener'.'ated', $data);
         $this->assertArrayHasKey('GET', $data);
         $this->assertContains(EndpointFixture::class, $data['GET']);
-    }
-
-    /**
-     * @param string[] $data
-     */
-    private function validateParserList(array $data): void
-    {
-        $this->assertArrayHasKey('@gener'.'ated', $data);
-        $this->assertArrayHasKey('application/json', $data);
-        $this->assertArrayHasKey('application/x-www-form-urlencoded', $data);
     }
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -11,6 +11,7 @@ use Firehed\API\Interfaces\EndpointInterface;
 use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
 use Firehed\API\Errors\HandlerInterface;
 use Firehed\Input\Exceptions\InputException;
+use Firehed\Input\Parsers;
 use InvalidArgumentException;
 use Nyholm\Psr7\ServerRequest;
 use OutOfBoundsException;
@@ -735,10 +736,12 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    private function getDefaultParserList(): string
+    private function getDefaultParserList(): array
     {
-        // This could also be dynamically built
-        return dirname(__DIR__).'/vendor/firehed/input/src/Parsers/__parser_list__.json';
+        return [
+            'application/json' => Parsers\JSON::class,
+            'application/x-www-form-urlencoded' => Parsers\URLEncoded::class,
+        ];
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -7,11 +7,11 @@ namespace Firehed\API;
 use Exception;
 use Firehed\API\Authentication;
 use Firehed\API\Authorization;
+use Firehed\API\Enums\HTTPMethod;
 use Firehed\API\Interfaces\EndpointInterface;
 use Firehed\API\Interfaces\HandlesOwnErrorsInterface;
 use Firehed\API\Errors\HandlerInterface;
 use Firehed\Input\Exceptions\InputException;
-use Firehed\Input\Parsers;
 use InvalidArgumentException;
 use Nyholm\Psr7\ServerRequest;
 use OutOfBoundsException;
@@ -81,17 +81,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /** @covers ::setParserList */
-    public function testSetParserListReturnsSelf(): void
-    {
-        $d = new Dispatcher();
-        $this->assertSame(
-            $d,
-            $d->setParserList('list'),
-            'setParserList did not return $this'
-        );
-    }
-
     // ----(Success case)-------------------------------------------------------
 
     /**
@@ -112,7 +101,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
-            ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         $this->checkResponse($response, 200);
         $data = json_decode((string)$response->getBody(), true);
@@ -143,7 +131,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
-            ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         $this->checkResponse($response, 200);
         $data = json_decode((string)$response->getBody(), true);
@@ -215,13 +202,12 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('execute')
             ->willReturn($response);
 
-        $routes = ['GET' => ['/c' => 'EP']];
+        $routes = [HTTPMethod::GET => ['/c' => 'EP']];
         $res = $dispatcher
             ->addMiddleware($mw1)
             ->addMiddleware($mw2)
             ->setContainer($this->getMockContainer(['EP' => $endpoint]))
             ->setEndpointList($routes)
-            ->setParserList($this->getDefaultParserList())
             ->dispatch($request);
 
         $this->assertSame($modifiedResponse, $res, 'Dispatcher returned different response');
@@ -252,7 +238,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
         $req = $this->getMockRequestWithUriPath('/cb', 'GET');
         $list = [
-            'GET' => [
+            HTTPMethod::GET => [
                 '/cb' => 'CBClass',
             ],
         ];
@@ -260,7 +246,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
             $ret = (new Dispatcher())
                 ->setContainer($this->getMockContainer(['CBClass' => $endpoint]))
                 ->setEndpointList($list)
-                ->setParserList($this->getDefaultParserList())
                 ->dispatch($req);
             $this->fail(
                 "The exception thrown from the error handler's failure should ".
@@ -299,7 +284,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionCode(404);
         $ret = (new Dispatcher())
             ->setEndpointList([]) // No routes
-            ->setParserList([])
             ->dispatch($req);
     }
 
@@ -317,7 +301,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         try {
             $response = (new Dispatcher())
                 ->setEndpointList($this->getEndpointListForFixture())
-                ->setParserList($this->getDefaultParserList())
                 ->dispatch($req);
             $this->fail('An exception should have been thrown');
         } catch (Throwable $e) {
@@ -334,7 +317,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         try {
             $response = (new Dispatcher())
                 ->setEndpointList($this->getEndpointListForFixture())
-                ->setParserList($this->getDefaultParserList())
                 ->dispatch($req);
             $this->fail('An exception should have been thrown');
         } catch (Throwable $e) {
@@ -354,7 +336,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $req = $req->withHeader('Content-type', $contentType);
         $response = (new Dispatcher())
             ->setEndpointList($this->getEndpointListForFixture())
-            ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         $this->checkResponse($response, 200);
     }
@@ -449,7 +430,6 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $request = $this->getMockRequestWithUriPath('/');
         $finalResponse = (new Dispatcher())
             ->setEndpointList([])
-            ->setParserList([])
             ->setContainer($container)
             ->dispatch($request);
         $this->assertSame($response, $finalResponse);
@@ -704,7 +684,7 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
     ): ResponseInterface {
         $req = $this->getMockRequestWithUriPath('/container', 'GET', []);
         $list = [
-            'GET' => [
+            HTTPMethod::GET => [
                 '/container' => 'ClassThatDoesNotExist',
             ],
         ];
@@ -718,29 +698,22 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $response = $dispatcher
             ->setContainer($this->getMockContainer($containerValues))
             ->setEndpointList($list)
-            ->setParserList($this->getDefaultParserList())
             ->dispatch($req);
         return $response;
     }
 
-    /** @return string[][] */
+    /**
+     * @return array<HTTPMethod::*, array<string, class-string<EndpointInterface>>>
+     */
     private function getEndpointListForFixture(): array
     {
         return [
-            'GET' => [
+            HTTPMethod::GET => [
                 '/user/(?P<id>[1-9]\d*)' => __NAMESPACE__.'\EndpointFixture'
             ],
-            'POST' => [
+            HTTPMethod::POST => [
                 '/user/(?P<id>[1-9]\d*)' => __NAMESPACE__.'\EndpointFixture'
             ],
-        ];
-    }
-
-    private function getDefaultParserList(): array
-    {
-        return [
-            'application/json' => Parsers\JSON::class,
-            'application/x-www-form-urlencoded' => Parsers\URLEncoded::class,
         ];
     }
 

--- a/tests/EndpointFixture.php
+++ b/tests/EndpointFixture.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 
 class EndpointFixture implements Interfaces\EndpointInterface
 {
+    use Traits\Request\Get;
 
     const STATUS_ERROR = 999;
 
@@ -52,11 +53,6 @@ class EndpointFixture implements Interfaces\EndpointInterface
                 }
             }
         ];
-    }
-
-    public function getMethod(): Enums\HTTPMethod
-    {
-        return Enums\HTTPMethod::GET();
     }
 
     public function execute(SafeInput $input): Response

--- a/tests/Traits/Request/DeleteTest.php
+++ b/tests/Traits/Request/DeleteTest.php
@@ -14,7 +14,7 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
             use Delete;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::DELETE(),
+            \Firehed\API\Enums\HTTPMethod::DELETE,
             $obj->getMethod(),
             'getMethod did not return HTTP DELETE'
         );

--- a/tests/Traits/Request/GetTest.php
+++ b/tests/Traits/Request/GetTest.php
@@ -14,7 +14,7 @@ class GetTest extends \PHPUnit\Framework\TestCase
             use Get;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::GET(),
+            \Firehed\API\Enums\HTTPMethod::GET,
             $obj->getMethod(),
             'getMethod did not return HTTP GET'
         );

--- a/tests/Traits/Request/OptionsTest.php
+++ b/tests/Traits/Request/OptionsTest.php
@@ -14,7 +14,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
             use Options;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::OPTIONS(),
+            \Firehed\API\Enums\HTTPMethod::OPTIONS,
             $obj->getMethod(),
             'getMethod did not return HTTP OPTIONS'
         );

--- a/tests/Traits/Request/PatchTest.php
+++ b/tests/Traits/Request/PatchTest.php
@@ -14,7 +14,7 @@ class PatchTest extends \PHPUnit\Framework\TestCase
             use Patch;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::PATCH(),
+            \Firehed\API\Enums\HTTPMethod::PATCH,
             $obj->getMethod(),
             'getMethod did not return HTTP PATCH'
         );

--- a/tests/Traits/Request/PostTest.php
+++ b/tests/Traits/Request/PostTest.php
@@ -14,7 +14,7 @@ class PostTest extends \PHPUnit\Framework\TestCase
             use Post;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::POST(),
+            \Firehed\API\Enums\HTTPMethod::POST,
             $obj->getMethod(),
             'getMethod did not return HTTP POST'
         );

--- a/tests/Traits/Request/PutTest.php
+++ b/tests/Traits/Request/PutTest.php
@@ -14,7 +14,7 @@ class PutTest extends \PHPUnit\Framework\TestCase
             use Put;
         };
         $this->assertEquals(
-            \Firehed\API\Enums\HTTPMethod::PUT(),
+            \Firehed\API\Enums\HTTPMethod::PUT,
             $obj->getMethod(),
             'getMethod did not return HTTP PUT'
         );


### PR DESCRIPTION
In preparation of supporting PHP 8.1, this removes use of a pseudo-`enum` implementation in favor of syntax-equivalent interface constants & traits. The endpoint map generation logic has been reworked to match, and may yield marginal performance improvements.